### PR TITLE
Solution for TS7006

### DIFF
--- a/src/WasmParser.ts
+++ b/src/WasmParser.ts
@@ -1865,7 +1865,7 @@ declare class TextDecoder {
   public decode(bytes: Uint8Array): string;
 }
 
-export var bytesToString: (Uint8Array) => string;
+export var bytesToString: (Uint8Array: any) => string;
 if (typeof TextDecoder !== 'undefined') {
   try {
     bytesToString = function () {


### PR DESCRIPTION
> ERROR in WasmParser.d.ts
>     TS7006: Parameter 'Uint8Array' implicitly has an 'any' type.

Another solution for users of this module can be to set `noImplicitAny: false` in tsconfig.json