### PR TITLE
Add ES-module output bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
 node_modules/
 dist/
+esm/
 npm-debug.log

--- a/es6-tsconfig.json
+++ b/es6-tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./esm/",
+    "target": "esnext",
+    "module": "esnext"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wasmparser",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.9.1",
   "description": "Binary WebAssembly file parser.",
   "main": "./dist/index.js",
+  "module": "./esm/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
     "disassemble-wasm": "./disassemble-wasm.js"
   },
   "scripts": {
     "test": "node ./test.js",
-    "build": "tsc"
+    "build": "tsc && tsc -p es6-tsconfig.json"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -20,7 +20,7 @@ import {
   IGlobalVariable, IElementSegment, IElementSegmentBody, ISectionInformation,
   IStartEntry, bytesToString, INameEntry, NameType, IFunctionNameEntry, INaming,
   NULL_FUNCTION_INDEX
-} from './WasmParser';
+} from './WasmParser.js';
 function typeToString(type: number): string {
   switch (type) {
     case Type.i32: return 'i32';

--- a/src/WasmEmitter.ts
+++ b/src/WasmEmitter.ts
@@ -21,7 +21,7 @@ import {
   IGlobalVariable, bytesToString, IRelocHeader, IRelocEntry, RelocType,
   INameEntry, NameType, IModuleNameEntry, IFunctionNameEntry, ILocalNameEntry,
   INaming, ILinkingEntry, LinkingType, ISourceMappingURL,
-} from './WasmParser';
+} from './WasmParser.js';
 
 enum EmitterState {
   Initial,

--- a/src/WasmParserTransform.ts
+++ b/src/WasmParserTransform.ts
@@ -14,9 +14,9 @@
  */
 
 import { Transform } from 'stream';
-import { BinaryReader, BinaryReaderState } from './WasmParser';
+import { BinaryReader, BinaryReaderState } from './WasmParser.js';
 
-export { BinaryReaderState, SectionCode } from './WasmParser';
+export { BinaryReaderState, SectionCode } from './WasmParser.js';
 
 export class BinaryReaderTransform extends Transform {
   private _buffer: ArrayBuffer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,13 +44,13 @@ export {
   IMemoryAddress,
   IOperatorInformation,
   IBinaryReaderData,
-} from './WasmParser';
+} from './WasmParser.js';
 export {
   Emitter,
-} from './WasmEmitter';
+} from './WasmEmitter.js';
 export {
   BinaryReaderTransform,
-} from './WasmParserTransform';
+} from './WasmParserTransform.js';
 export {
   DefaultNameResolver,
   NumericNameResolver,
@@ -58,4 +58,4 @@ export {
   LabelMode,
   IDisassemblerResult,
   INameResolver,
-} from './WasmDis';
+} from './WasmDis.js';


### PR DESCRIPTION
Add an output module that uses standard ES modules with proper file extensions.
This bundle is exposed via the "module" attribute in the package.json.
The es6-tsconfig.json overrides only the necessary parts of the base config.

This is a follow-up on #22 `require` can use the file extension at the end in Node. File extensions are required when downstream users use standard ES modules. Verified that tests are still passing and the build output is correct.

CC @ericsl