### PR TITLE
Add option to truncate disassembly

### DIFF
--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -314,6 +314,7 @@ export class WasmDisassembler {
   private _currentPosition: number;
   private _nameResolver: INameResolver;
   private _labelMode: LabelMode;
+  private _maxLines: number;
   constructor() {
     this._lines = [];
     this._offsets = [];
@@ -339,6 +340,7 @@ export class WasmDisassembler {
     this._initExpression = [];
     this._backrefLabels = null;
     this._labelIndex = 0;
+    this._maxLines = 0;
   }
   public get addOffsets() {
     return this._addOffsets;
@@ -363,6 +365,9 @@ export class WasmDisassembler {
     if (this._currentPosition)
       throw new Error('Cannot switch nameResolver during processing.');
     this._nameResolver = resolver;
+  }
+  public set maxLines(value: number) {
+    this._maxLines = value;
   }
   private appendBuffer(s: string) {
     this._buffer += s;
@@ -732,6 +737,11 @@ export class WasmDisassembler {
     if (this._done)
       throw new Error('Invalid state: disassembly process was already finished.')
     while (true) {
+      if (this._maxLines && this._lines.length >= this._maxLines) {
+        this.appendBuffer(';; -- text is truncated due to size --');
+        this.newLine();
+        return true;
+      }
       this._currentPosition = reader.position + offsetInModule;
       if (!reader.read())
         return false;

--- a/test.ts
+++ b/test.ts
@@ -36,3 +36,28 @@ readdirSync(TEST_FOLDER)
       expect(out).toBe(outFileData);
     });
   });
+
+for (const maxLines of [1, 3, 6, 7, 8, 20, 30, 32, 34, 35, 36, 37, 38, 39, 80]) {
+  test(`truncate_after_${maxLines}`, () => {
+    const testFilePath = join(TEST_FOLDER, "memory_bulk.0.wasm");
+    let dis = new WasmDisassembler();
+    dis.maxLines = maxLines;
+    let data = new Uint8Array(readFileSync(testFilePath));
+    let parser = new BinaryReader();
+    parser.setData(data.buffer, 0, data.length);
+    let out = dis.disassemble(parser);
+    let outFile = testFilePath + ".out";
+    let outFileData = readFileSync(outFile, "utf8");
+    let outLines = out.trimRight().split("\n");
+    let allLines = outFileData.trimRight().split("\n");
+    if (outLines.length > maxLines) {
+      // truncated case
+      expect(outLines.length).toBe(maxLines + 1);
+      expect(outLines[maxLines]).toMatch("truncated");
+      expect(outLines.slice(0, maxLines).join("\n")).toBe(allLines.slice(0, maxLines).join("\n"));
+    } else {
+      // full file should be output
+      expect(out).toBe(outFileData);
+    }
+  });
+}


### PR DESCRIPTION
Quick change to produce a truncated output. This may not be worth merging in as it is not our long term solution.