### PR TITLE
Adding DevToolsNameGenerator and DevToolsNameResolver

### DIFF
--- a/src/WasmDis.spec.ts
+++ b/src/WasmDis.spec.ts
@@ -15,9 +15,185 @@
  */
 
 import { NameSectionReader } from "./WasmDis";
+import { DevToolsNameGenerator } from "./WasmDis";
 import { BinaryReader } from "./WasmParser";
 
 const { parseWat } = require("wabt")();
+
+describe("DevToolsNameGenerator", () => {
+  test("Empty Wasm module", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const ng = new DevToolsNameGenerator();
+    ng.read(reader);
+    expect(ng.hasValidNames()).toBe(false);
+    expect(ng.getNameResolver.bind(ng)).toThrowError();
+  });
+
+  test("Wasm module with export names only for function, memory, global and table", () => {
+    const { buffer } = parseWat(
+        `test.wat`,
+	`(module
+         (export "export.function" (func 0))
+         (export "export.memory" (memory 0))
+         (export "export.table" (table 0))
+         (export "export.global" (global 0))
+         (func)
+         (memory 0)
+         (table 1 funcref)
+         (global i32 (i32.const 0)))`
+    ).toBinary({ write_debug_names: true });
+    const reader = new BinaryReader();
+    reader.setData(buffer.buffer, 0, buffer.byteLength);
+    const ng = new DevToolsNameGenerator();
+    ng.read(reader);
+    expect(ng.hasValidNames()).toBe(true);
+    const nr = ng.getNameResolver();
+    expect(nr.getFunctionName(0, false, true)).toBe("$export.function");
+    expect(nr.getFunctionName(0, false, false)).toBe("$export.function (;0;)");
+    expect(nr.getMemoryName(0, true)).toBe("$export.memory");
+    expect(nr.getMemoryName(0, false)).toBe("$export.memory (;0;)");
+    expect(nr.getTableName(0, true)).toBe("$export.table");
+    expect(nr.getTableName(0, false)).toBe("$export.table (;0;)");
+    expect(nr.getGlobalName(0, true)).toBe("$export.global");
+    expect(nr.getGlobalName(0, false)).toBe("$export.global (;0;)");
+  });
+
+  test("Wasm module with import names only for function, memory, global and table", () => {
+    const { buffer } = parseWat(
+        `test.wat`,
+	`(module
+         (import "import" "function" (func))
+         (import "import" "memory" (memory 0))
+         (import "import" "table" (table 1 funcref))
+         (import "import" "global" (global i32)))`
+    ).toBinary({ write_debug_names: true });
+    const reader = new BinaryReader();
+    reader.setData(buffer.buffer, 0, buffer.byteLength);
+    const ng = new DevToolsNameGenerator();
+    ng.read(reader);
+    expect(ng.hasValidNames()).toBe(true);
+    const nr = ng.getNameResolver();
+    expect(nr.getFunctionName(0, true, true)).toBe("$import.function");
+    expect(nr.getFunctionName(0, true, false)).toBe("$import.function (;0;)");
+    expect(nr.getMemoryName(0, true)).toBe("$import.memory");
+    expect(nr.getMemoryName(0, false)).toBe("$import.memory (;0;)");
+    expect(nr.getTableName(0, true)).toBe("$import.table");
+    expect(nr.getTableName(0, false)).toBe("$import.table (;0;)");
+    expect(nr.getGlobalName(0, true)).toBe("$import.global");
+    expect(nr.getGlobalName(0, false)).toBe("$import.global (;0;)");
+  });
+
+  test("Wasm module with function and export name", () => {
+    const { buffer } = parseWat(
+        `test.wat`,
+        `(module
+         (export "export.function" (func $f))
+         (func $f (result i32) i32.const 0))`
+  ).toBinary({ write_debug_names: true });
+    const reader = new BinaryReader();
+    reader.setData(buffer.buffer, 0, buffer.byteLength);
+    const ng = new DevToolsNameGenerator();
+    ng.read(reader);
+    expect(ng.hasValidNames()).toBe(true);
+    const nr = ng.getNameResolver();
+    expect(nr.getFunctionName(0, false, true)).toBe("$f");
+    expect(nr.getFunctionName(0, false, false)).toBe("$f (;0;)");
+  });
+
+  test("Wasm module with import and export name", () => {
+    const { buffer } = parseWat(
+        `test.wat`,
+        `(module
+         (import "import" "function" (func))
+         (export "export.function" (func 0)))`
+  ).toBinary({ write_debug_names: true });
+    const reader = new BinaryReader();
+    reader.setData(buffer.buffer, 0, buffer.byteLength);
+    const ng = new DevToolsNameGenerator();
+    ng.read(reader);
+    expect(ng.hasValidNames()).toBe(true);
+    const nr = ng.getNameResolver();
+    expect(nr.getFunctionName(0, true, true)).toBe("$import.function");
+    expect(nr.getFunctionName(0, true, false)).toBe("$import.function (;0;)");
+  });
+
+  test("Wasm module with no set names", () => {
+      const { buffer } = parseWat(
+          `test.wat`,
+          `(module
+           (import "" "" (func))
+           (export "" (func 0))
+           (func)
+           (memory 0)
+           (table 1 funcref)
+           (global i32 (i32.const 0)))`
+      ).toBinary({ write_debug_names: true });
+      const reader = new BinaryReader();
+      reader.setData(buffer.buffer, 0, buffer.byteLength);
+      const ng = new DevToolsNameGenerator();
+      ng.read(reader);
+      expect(ng.hasValidNames()).toBe(true);
+      const nr = ng.getNameResolver();
+      expect(nr.getFunctionName(0, true, true)).toBe("$import0");
+      expect(nr.getFunctionName(0, true, false)).toBe("$import0");
+      expect(nr.getFunctionName(1, false, true)).toBe("$func1");
+      expect(nr.getFunctionName(1, false, false)).toBe("$func1");
+      expect(nr.getMemoryName(0, true)).toBe("$memory0");
+      expect(nr.getMemoryName(0, false)).toBe("$memory0");
+      expect(nr.getTableName(0, true)).toBe("$table0");
+      expect(nr.getTableName(0, false)).toBe("$table0");
+      expect(nr.getGlobalName(0, false)).toBe("$global0");
+      expect(nr.getGlobalName(0, false)).toBe("$global0");
+  });
+
+  test("Wasm module with defined and undefined param names", () => {
+      const { buffer } = parseWat(
+          `test.wat`,
+          `(module
+           (func (param i32) (param $x i32)))`
+      ).toBinary({ write_debug_names: true });
+      const reader = new BinaryReader();
+      reader.setData(buffer.buffer, 0, buffer.byteLength);
+      const ng = new DevToolsNameGenerator();
+      ng.read(reader);
+      expect(ng.hasValidNames()).toBe(true);
+      const nr = ng.getNameResolver();
+      expect(nr.getVariableName(0, 0, true)).toBe("$var0");
+      expect(nr.getVariableName(0, 0, false)).toBe("$var0");
+      expect(nr.getVariableName(0, 1, true)).toBe("$x");
+      expect(nr.getVariableName(0, 1, false)).toBe("$x (;1;)");
+  });
+
+  test("Wasm module with defined and undefined local names", () => {
+      const { buffer } = parseWat(
+          `test.wat`,
+          `(module
+           (func (local i32) (local $x i32)))`
+      ).toBinary({ write_debug_names: true });
+      const reader = new BinaryReader();
+      reader.setData(buffer.buffer, 0, buffer.byteLength);
+      const ng = new DevToolsNameGenerator();
+      ng.read(reader);
+      expect(ng.hasValidNames()).toBe(true);
+      const nr = ng.getNameResolver();
+      expect(nr.getVariableName(0, 0, true)).toBe("$var0");
+      expect(nr.getVariableName(0, 0, false)).toBe("$var0");
+      expect(nr.getVariableName(0, 1, true)).toBe("$x");
+      expect(nr.getVariableName(0, 1, false)).toBe("$x (;1;)");
+  });
+});
 
 describe("NameSectionReader", () => {
   test("Empty Wasm module", () => {

--- a/src/WasmDis.spec.ts
+++ b/src/WasmDis.spec.ts
@@ -85,6 +85,8 @@ describe("DevToolsNameGenerator", () => {
     ng.read(reader);
     expect(ng.hasValidNames()).toBe(true);
     const nr = ng.getNameResolver();
+    expect(nr.getTypeName(0, true)).toBe("$type0");
+    expect(nr.getTypeName(0, false)).toBe("$type0");
     expect(nr.getFunctionName(0, true, true)).toBe("$import.function");
     expect(nr.getFunctionName(0, true, false)).toBe("$import.function (;0;)");
     expect(nr.getMemoryName(0, true)).toBe("$import.memory");
@@ -146,8 +148,8 @@ describe("DevToolsNameGenerator", () => {
       ng.read(reader);
       expect(ng.hasValidNames()).toBe(true);
       const nr = ng.getNameResolver();
-      expect(nr.getFunctionName(0, true, true)).toBe("$import0");
-      expect(nr.getFunctionName(0, true, false)).toBe("$import0");
+      expect(nr.getFunctionName(0, true, true)).toBe("$.");
+      expect(nr.getFunctionName(0, true, false)).toBe("$. (;0;)");
       expect(nr.getFunctionName(1, false, true)).toBe("$func1");
       expect(nr.getFunctionName(1, false, false)).toBe("$func1");
       expect(nr.getMemoryName(0, true)).toBe("$memory0");

--- a/src/WasmDis.spec.ts
+++ b/src/WasmDis.spec.ts
@@ -21,26 +21,6 @@ import { BinaryReader } from "./WasmParser";
 const { parseWat } = require("wabt")();
 
 describe("DevToolsNameGenerator", () => {
-  test("Empty Wasm module", () => {
-    const data = new Uint8Array([
-      // Wasm header
-      0x00,
-      0x61,
-      0x73,
-      0x6d,
-      0x01,
-      0x00,
-      0x00,
-      0x00
-    ]);
-    const reader = new BinaryReader();
-    reader.setData(data.buffer, 0, data.byteLength);
-    const ng = new DevToolsNameGenerator();
-    ng.read(reader);
-    expect(ng.hasValidNames()).toBe(false);
-    expect(ng.getNameResolver.bind(ng)).toThrowError();
-  });
-
   test("Wasm module with export names only for function, memory, global and table", () => {
     const { buffer } = parseWat(
         `test.wat`,
@@ -58,7 +38,6 @@ describe("DevToolsNameGenerator", () => {
     reader.setData(buffer.buffer, 0, buffer.byteLength);
     const ng = new DevToolsNameGenerator();
     ng.read(reader);
-    expect(ng.hasValidNames()).toBe(true);
     const nr = ng.getNameResolver();
     expect(nr.getFunctionName(0, false, true)).toBe("$export.function");
     expect(nr.getFunctionName(0, false, false)).toBe("$export.function (;0;)");
@@ -83,7 +62,6 @@ describe("DevToolsNameGenerator", () => {
     reader.setData(buffer.buffer, 0, buffer.byteLength);
     const ng = new DevToolsNameGenerator();
     ng.read(reader);
-    expect(ng.hasValidNames()).toBe(true);
     const nr = ng.getNameResolver();
     expect(nr.getTypeName(0, true)).toBe("$type0");
     expect(nr.getTypeName(0, false)).toBe("$type0");
@@ -108,7 +86,6 @@ describe("DevToolsNameGenerator", () => {
     reader.setData(buffer.buffer, 0, buffer.byteLength);
     const ng = new DevToolsNameGenerator();
     ng.read(reader);
-    expect(ng.hasValidNames()).toBe(true);
     const nr = ng.getNameResolver();
     expect(nr.getFunctionName(0, false, true)).toBe("$f");
     expect(nr.getFunctionName(0, false, false)).toBe("$f (;0;)");
@@ -125,7 +102,6 @@ describe("DevToolsNameGenerator", () => {
     reader.setData(buffer.buffer, 0, buffer.byteLength);
     const ng = new DevToolsNameGenerator();
     ng.read(reader);
-    expect(ng.hasValidNames()).toBe(true);
     const nr = ng.getNameResolver();
     expect(nr.getFunctionName(0, true, true)).toBe("$import.function");
     expect(nr.getFunctionName(0, true, false)).toBe("$import.function (;0;)");
@@ -146,7 +122,6 @@ describe("DevToolsNameGenerator", () => {
       reader.setData(buffer.buffer, 0, buffer.byteLength);
       const ng = new DevToolsNameGenerator();
       ng.read(reader);
-      expect(ng.hasValidNames()).toBe(true);
       const nr = ng.getNameResolver();
       expect(nr.getFunctionName(0, true, true)).toBe("$.");
       expect(nr.getFunctionName(0, true, false)).toBe("$. (;0;)");
@@ -170,7 +145,6 @@ describe("DevToolsNameGenerator", () => {
       reader.setData(buffer.buffer, 0, buffer.byteLength);
       const ng = new DevToolsNameGenerator();
       ng.read(reader);
-      expect(ng.hasValidNames()).toBe(true);
       const nr = ng.getNameResolver();
       expect(nr.getVariableName(0, 0, true)).toBe("$var0");
       expect(nr.getVariableName(0, 0, false)).toBe("$var0");
@@ -188,7 +162,6 @@ describe("DevToolsNameGenerator", () => {
       reader.setData(buffer.buffer, 0, buffer.byteLength);
       const ng = new DevToolsNameGenerator();
       ng.read(reader);
-      expect(ng.hasValidNames()).toBe(true);
       const nr = ng.getNameResolver();
       expect(nr.getVariableName(0, 0, true)).toBe("$var0");
       expect(nr.getVariableName(0, 0, false)).toBe("$var0");
@@ -207,7 +180,6 @@ describe("DevToolsNameGenerator", () => {
     reader.setData(buffer.buffer, 0, buffer.byteLength);
     const ng = new DevToolsNameGenerator();
     ng.read(reader);
-    expect(ng.hasValidNames()).toBe(true);
     const nr = ng.getNameResolver();
     expect(nr.getFunctionName(0, false, true)).toBe("$__");
     expect(nr.getFunctionName(0, false, false)).toBe("$__ (;0;)");

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -24,7 +24,8 @@ import {
 } from './WasmParser.js';
 
 const NAME_SECTION_NAME = "name";
-const INVALID_NAME_SYMBOLS_REGEX = /[^0-9A-Za-z!#$%&'*+.:<=>?@^_`|~\/\-]/g;
+const INVALID_NAME_SYMBOLS_REGEX = /[^0-9A-Za-z!#$%&'*+.:<=>?@^_`|~\/\-]/;
+const INVALID_NAME_SYMBOLS_REGEX_GLOBAL = new RegExp(INVALID_NAME_SYMBOLS_REGEX.source, "g");
 
 function typeToString(type: number): string {
   switch (type) {
@@ -1259,12 +1260,12 @@ export class DevToolsNameGenerator {
   }
 
   private _generateExportName(field: Uint8Array) : string {
-    return bytesToString(field).replace(INVALID_NAME_SYMBOLS_REGEX, '_');
+    return bytesToString(field).replace(INVALID_NAME_SYMBOLS_REGEX_GLOBAL, '_');
   }
 
   private _generateImportName(moduleName: Uint8Array, field: Uint8Array) : string {
     const name = bytesToString(moduleName) + '.' + bytesToString(field);
-    return name.replace(INVALID_NAME_SYMBOLS_REGEX,'_');
+    return name.replace(INVALID_NAME_SYMBOLS_REGEX_GLOBAL,'_');
   }
 
   private _setName(names: string[], index: number, name: string, isNameSectionName: boolean) {

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -24,6 +24,7 @@ import {
 } from './WasmParser.js';
 
 const NAME_SECTION_NAME = "name";
+const INVALID_NAME_SYMBOLS_REGEX = /[^0-9A-Za-z!#$%&'*+.:<=>?@^_`|~\/\-]/g;
 
 function typeToString(type: number): string {
   switch (type) {
@@ -229,7 +230,7 @@ function getOperatorName(code: OperatorCode): string {
 }
 
 function isValidName(name : string) {
-  return !/[^0-9A-Za-z!#$%&'*+.:<=>?@^_`|~\/\-]/.test(name);
+  return !INVALID_NAME_SYMBOLS_REGEX.test(name);
 }
 
 export interface INameResolver {
@@ -1258,12 +1259,12 @@ export class DevToolsNameGenerator {
   }
 
   private _generateExportName(field: Uint8Array) : string {
-    return bytesToString(field).replace(/\s/g, '_');
+    return bytesToString(field).replace(INVALID_NAME_SYMBOLS_REGEX, '_');
   }
 
   private _generateImportName(moduleName: Uint8Array, field: Uint8Array) : string {
     const name = bytesToString(moduleName) + '.' + bytesToString(field);
-    return name.replace(/\s/g, '_');
+    return name.replace(INVALID_NAME_SYMBOLS_REGEX,'_');
   }
 
   private _setName(names: string[], index: number, name: string, isNameSectionName: boolean) {

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -1268,8 +1268,7 @@ export class DevToolsNameGenerator {
   }
 
   private _generateExportName(field: Uint8Array) : string {
-    const exportName = bytesToString(field).replace(/\s/g, '_');
-    return exportName.replace(/\s/g, '_');
+    return bytesToString(field).replace(/\s/g, '_');
   }
 
   private _generateImportName(moduleName: Uint8Array, field: Uint8Array) : string {

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -1232,7 +1232,6 @@ export class NameSectionReader {
 
 export class DevToolsNameGenerator {
   private _done: boolean;
-  private _hasNames: boolean;
   private _functionImportsCount: number;
   private _memoryImportsCount: number;
   private _tableImportsCount: number;
@@ -1246,7 +1245,6 @@ export class DevToolsNameGenerator {
 
   constructor() {
     this._done = false;
-    this._hasNames = false;
     this._functionImportsCount = 0;
     this._memoryImportsCount = 0;
     this._tableImportsCount = 0;
@@ -1325,7 +1323,6 @@ export class DevToolsNameGenerator {
           const importName = this._generateImportName(importInfo.module, importInfo.field);
           if (!importName)
             continue;
-          this._hasNames = true;
           switch (importInfo.kind) {
             case ExternalKind.Function:
               this._setName(this._functionNames, this._functionImportsCount++, importName, false);
@@ -1350,7 +1347,6 @@ export class DevToolsNameGenerator {
             functionNameInfo.names.forEach((naming: INaming) => {
               this._setName(this._functionNames, naming.index, bytesToString(naming.name), true);
             });
-            this._hasNames = true;
           } else if (nameInfo.type === NameType.Local) {
             var localNameInfo = <ILocalNameEntry>nameInfo;
             localNameInfo.funcs.forEach(localName => {
@@ -1359,7 +1355,6 @@ export class DevToolsNameGenerator {
                 this._functionLocalNames[localName.index][naming.index] = bytesToString(naming.name);
               });
             });
-            this._hasNames = true;
           }
           break;
         case BinaryReaderState.EXPORT_SECTION_ENTRY:
@@ -1367,7 +1362,6 @@ export class DevToolsNameGenerator {
           const exportName = this._generateExportName(exportInfo.field);
           if (!exportName)
             continue;
-          this._hasNames = true;
           switch (exportInfo.kind) {
             case ExternalKind.Function:
               this._setName(this._functionNames, exportInfo.index, exportName, false);
@@ -1391,14 +1385,7 @@ export class DevToolsNameGenerator {
     }
   }
 
-  public hasValidNames(): boolean {
-    return this._hasNames;
-  }
-
   public getNameResolver(): INameResolver {
-    if (!this.hasValidNames())
-      throw new Error("Has no valid name section");
-
     return new DevToolsNameResolver(this._functionNames, this._functionLocalNames,
                                     this._memoryNames, this._tableNames, this._globalNames);
   }

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -22,6 +22,9 @@ import {
   NULL_FUNCTION_INDEX,
   ILocalNameEntry
 } from './WasmParser.js';
+
+const NAME_SECTION_NAME = "name";
+
 function typeToString(type: number): string {
   switch (type) {
     case Type.i32: return 'i32';
@@ -1148,7 +1151,7 @@ export class NameSectionReader {
         case BinaryReaderState.BEGIN_SECTION:
           var sectionInfo = <ISectionInformation>reader.result;
           if (sectionInfo.id === SectionCode.Custom &&
-              bytesToString(sectionInfo.name) === "name") {
+              bytesToString(sectionInfo.name) === NAME_SECTION_NAME) {
             break;
           }
           if (sectionInfo.id === SectionCode.Function ||
@@ -1303,7 +1306,7 @@ export class DevToolsNameGenerator {
           var sectionInfo = <ISectionInformation>reader.result;
 
           if (sectionInfo.id === SectionCode.Custom &&
-              bytesToString(sectionInfo.name) === "name") {
+              bytesToString(sectionInfo.name) === NAME_SECTION_NAME) {
             break;
           }
           switch (sectionInfo.id) {

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -225,6 +225,10 @@ function getOperatorName(code: OperatorCode): string {
   return operatorCodeNamesCache[code];
 }
 
+function isValidName(name : string) {
+  return !/[^0-9A-Za-z!#$%&'*+.:<=>?@^_`|~\/\-]/.test(name);
+}
+
 export interface INameResolver {
   getTypeName(index: number, isRef: boolean): string;
   getTableName(index: number, isRef: boolean): string;
@@ -1203,7 +1207,7 @@ export class NameSectionReader {
       if (!name)
         continue;
       const goodName = !(name in usedNameAt) &&
-                       !/[^0-9A-Za-z!#$%&'*+.:<=>?@^_`|~\/\-]/.test(name) &&
+                       isValidName(name) &&
                        name.indexOf(UNKNOWN_FUNCTION_PREFIX) !== 0;
       if (!goodName) {
         if (usedNameAt[name] >= 0) {
@@ -1260,6 +1264,8 @@ export class DevToolsNameGenerator {
   }
 
   private _setName(names: string[], index: number, name: string, isNameSectionName: boolean) {
+    if (!isValidName(name)) return;
+
     if (isNameSectionName || !names[index])
       names[index] = name;
   }

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -289,24 +289,28 @@ export class DevToolsNameResolver extends DefaultNameResolver {
       return super.getTableName(index, isRef);
     return isRef ? `$${name}` : `$${name} (;${index};)`;
   }
+
   public getMemoryName(index: number, isRef: boolean): string {
     const name = this._memoryNames[index];
     if (!name)
       return super.getMemoryName(index, isRef);
     return isRef ? `$${name}` : `$${name} (;${index};)`;
   }
+
   public getGlobalName(index: number, isRef: boolean): string {
     const name = this._globalNames[index];
     if (!name)
       return super.getGlobalName(index, isRef);
     return isRef ? `$${name}` : `$${name} (;${index};)`;
   }
+
   public getFunctionName(index: number, isImport: boolean, isRef: boolean): string {
     const name = this._functionNames[index];
     if (!name)
       return super.getFunctionName(index, isImport, isRef);
     return isRef ? `$${name}` : `$${name} (;${index};)`;
   }
+
   public getVariableName(funcIndex: number, index: number, isRef: boolean): string {
     const name = this._localNames[funcIndex] && this._localNames[funcIndex][index];
     if (!name)


### PR DESCRIPTION
This adds a new DevToolsNameGenerator class (similar to the NameSectionReader), which is responsible for generating the names depending on the name source (import, export, name section). The corresponding DevToolsNameResolver can then be used to resolve the names during disassembling wasm binaries.

The new DevToolsNameGenerator will adhere to the following naming scheme, if no name is set in the name section:

1. For entities (functions, tables, memories, or globals) that are imported, and which have both a <module_name> and a <field_name>, we generate a name in the form $<module_name>.<field_name>.
2. Otherwise, for entities (functions, tables, memories, or globals) that are exported, we take the first entry in the exports table and generate a name $<export_name>.
3. Otherwise:
- Types use $type#.
- Tables use $table#.
- Memories use $memory#.
- Global variables use $global#.
- Functions use $import# when the function is imported, and $func# otherwise.
- Local variables (and in particular parameters) use $var#.
- Labels use $label#

Furthermore, adhering to the NameResolver's naming scheme (for variables and functions), if the name is known and if it is a reference, we print the index too: e.g. $foo (;0;). This is now also introduced for tables, globals and memory.
