### PR TITLE
Log the body function offsets for better detecting possible breakable WAT positions

### DIFF
--- a/src/WasmDis.spec.ts
+++ b/src/WasmDis.spec.ts
@@ -295,7 +295,8 @@ describe("WasmDisassembler.getResult() with function code", () => {
   const watString =
   `(module
   (export "export.function" (func $f))
-  (func $f (result i32) i32.const 0))`;
+  (func $f (result i32) i32.const 0)
+  (func $f1 (result i32) i32.const 1))`;
   const fileName = `test.wat`;
   const expectedLines = [
     "(module",
@@ -303,6 +304,9 @@ describe("WasmDisassembler.getResult() with function code", () => {
     "  (export \"export.function\" (func $func0))",
     "  (func $func0 (result i32)",
     "    i32.const 0",
+    "  )",
+    "  (func $func1 (result i32)",
+    "    i32.const 1",
     "  )",
     ")",
   ];
@@ -320,8 +324,8 @@ describe("WasmDisassembler.getResult() with function code", () => {
     const result = dis.getResult();
     expect(result.done).toBe(true);
     expect(result.lines).toEqual(expectedLines);
-    expect(result.offsets).toEqual([0, 10, 21, 42, 45, 47, 66,]);
-    expect(result.codeSectionOffsets).toEqual([40, 48]);
+    expect(result.offsets).toEqual([0, 10, 22, 43, 46, 48, 49, 51, 53, 78,]);
+    expect(result.bodyFunctionOffsets).toEqual([[43, 49,], [49, 54,], ]);
   });
 
   test("addOffsets is false", () => {
@@ -338,7 +342,7 @@ describe("WasmDisassembler.getResult() with function code", () => {
     expect(result.done).toBe(true);
     expect(result.lines).toEqual(expectedLines);
     expect(result.offsets).toBeUndefined();
-    expect(result.codeSectionOffsets).toBeUndefined();
+    expect(result.bodyFunctionOffsets).toBeUndefined();
   });
 });
 
@@ -370,7 +374,7 @@ describe("WasmDisassembler.getResult() without function code", () => {
     expect(result.done).toBe(true);
     expect(result.lines).toEqual(expectedLines);
     expect(result.offsets).toEqual([0, 10, 16, 37, 68, ]);
-    expect(result.codeSectionOffsets).toEqual([]);
+    expect(result.bodyFunctionOffsets).toEqual([]);
   });
 
   test("addOffsets is false", () => {
@@ -387,6 +391,6 @@ describe("WasmDisassembler.getResult() without function code", () => {
     expect(result.done).toBe(true);
     expect(result.lines).toEqual(expectedLines);
     expect(result.offsets).toBeUndefined();
-    expect(result.codeSectionOffsets).toBeUndefined();
+    expect(result.bodyFunctionOffsets).toBeUndefined();
   });
 });

--- a/src/WasmDis.spec.ts
+++ b/src/WasmDis.spec.ts
@@ -325,7 +325,7 @@ describe("WasmDisassembler.getResult() with function code", () => {
     expect(result.done).toBe(true);
     expect(result.lines).toEqual(expectedLines);
     expect(result.offsets).toEqual([0, 10, 22, 43, 46, 48, 49, 51, 53, 78,]);
-    expect(result.bodyFunctionOffsets).toEqual([[43, 49,], [49, 54,], ]);
+    expect(result.functionBodyOffsets).toEqual([[43, 49,], [49, 54,], ]);
   });
 
   test("addOffsets is false", () => {
@@ -342,7 +342,7 @@ describe("WasmDisassembler.getResult() with function code", () => {
     expect(result.done).toBe(true);
     expect(result.lines).toEqual(expectedLines);
     expect(result.offsets).toBeUndefined();
-    expect(result.bodyFunctionOffsets).toBeUndefined();
+    expect(result.functionBodyOffsets).toBeUndefined();
   });
 });
 
@@ -374,7 +374,7 @@ describe("WasmDisassembler.getResult() without function code", () => {
     expect(result.done).toBe(true);
     expect(result.lines).toEqual(expectedLines);
     expect(result.offsets).toEqual([0, 10, 16, 37, 68, ]);
-    expect(result.bodyFunctionOffsets).toEqual([]);
+    expect(result.functionBodyOffsets).toEqual([]);
   });
 
   test("addOffsets is false", () => {
@@ -391,6 +391,6 @@ describe("WasmDisassembler.getResult() without function code", () => {
     expect(result.done).toBe(true);
     expect(result.lines).toEqual(expectedLines);
     expect(result.offsets).toBeUndefined();
-    expect(result.bodyFunctionOffsets).toBeUndefined();
+    expect(result.functionBodyOffsets).toBeUndefined();
   });
 });

--- a/src/WasmDis.spec.ts
+++ b/src/WasmDis.spec.ts
@@ -295,7 +295,9 @@ describe("WasmDisassembler.getResult() with function code", () => {
   const watString =
   `(module
   (export "export.function" (func $f))
-  (func $f (result i32) i32.const 0)
+  (func $f (result i32)
+  (local $x i32)
+  i32.const 0)
   (func $f1 (result i32) i32.const 1))`;
   const fileName = `test.wat`;
   const expectedLines = [
@@ -303,6 +305,7 @@ describe("WasmDisassembler.getResult() with function code", () => {
     "  (type $type0 (func (result i32)))",
     "  (export \"export.function\" (func $func0))",
     "  (func $func0 (result i32)",
+    "    (local $var0 i32)",
     "    i32.const 0",
     "  )",
     "  (func $func1 (result i32)",
@@ -324,8 +327,18 @@ describe("WasmDisassembler.getResult() with function code", () => {
     const result = dis.getResult();
     expect(result.done).toBe(true);
     expect(result.lines).toEqual(expectedLines);
-    expect(result.offsets).toEqual([0, 10, 22, 43, 46, 48, 49, 51, 53, 78,]);
-    expect(result.functionBodyOffsets).toEqual([[43, 49,], [49, 54,], ]);
+    expect(result.offsets).toEqual([0, 10, 22, 43, 43, 48, 50, 51, 53, 55, 83]);
+    expect(result.functionBodyOffsets).toEqual(
+      [
+        {
+          start: 48,
+          end: 51,
+        },
+        {
+          start: 53,
+          end: 56,
+        },
+      ]);
   });
 
   test("addOffsets is false", () => {

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -470,7 +470,7 @@ export class WasmDisassembler {
     }
   }
   private logEndOfFunctionBodyOffset() {
-    if (this.addOffsets && this._currentFunctionBodyOffset?.start) {
+    if (this.addOffsets && this._currentFunctionBodyOffset) {
       this._currentFunctionBodyOffset.end = this._currentPosition;
       this._functionBodyOffsets.push(this._currentFunctionBodyOffset);
       this._currentFunctionBodyOffset = null;

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -789,6 +789,7 @@ export class WasmDisassembler {
     let result = lines.join('\n');
     this._lines.length = 0;
     this._offsets.length = 0;
+    this._functionBodyOffsets.length = 0;
     return result;
   }
   public getResult(): IDisassemblerResult {

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -361,7 +361,7 @@ export interface IDisassemblerResult {
   lines: Array<string>;
   offsets?: Array<number>;
   done: boolean;
-  bodyFunctionOffsets?: Array<Array<number>>;
+  functionBodyOffsets?: Array<Array<number>>;
 }
 
 export class WasmDisassembler {
@@ -387,8 +387,8 @@ export class WasmDisassembler {
   private _nameResolver: INameResolver;
   private _labelMode: LabelMode;
   private _maxLines: number;
-  private _bodyFunctionOffsets: Array<Array<number>>;
-  private _currentBodyFunctionOffset: Array<number>;
+  private _functionBodyOffsets: Array<Array<number>>;
+  private _currentFunctionBodyOffset: Array<number>;
   constructor() {
     this._lines = [];
     this._offsets = [];
@@ -400,8 +400,8 @@ export class WasmDisassembler {
     this._currentPosition = 0;
     this._nameResolver = new DefaultNameResolver();
     this._labelMode = LabelMode.WhenUsed;
-    this._bodyFunctionOffsets = [];
-    this._currentBodyFunctionOffset = [];
+    this._functionBodyOffsets = [];
+    this._currentFunctionBodyOffset = [];
 
     this._reset();
   }
@@ -456,13 +456,14 @@ export class WasmDisassembler {
   }
   private logStartOfBodyFunctionOffset() {
     if (this.addOffsets) {
-      this._currentBodyFunctionOffset = [this._currentPosition];
+      this._currentFunctionBodyOffset = [this._currentPosition];
     }
   }
   private logEndOfBodyFunctionOffset() {
-    if (this.addOffsets && this._currentBodyFunctionOffset.length == 1) {
-      this._currentBodyFunctionOffset.push(this._currentPosition);
-      this._bodyFunctionOffsets.push(this._currentBodyFunctionOffset);
+    if (this.addOffsets && this._currentFunctionBodyOffset.length == 1) {
+      this._currentFunctionBodyOffset.push(this._currentPosition);
+      this._functionBodyOffsets.push(this._currentFunctionBodyOffset);
+      this._currentFunctionBodyOffset = [];
     }
   }
   private printFuncType(typeIndex: number): void {
@@ -795,7 +796,7 @@ export class WasmDisassembler {
         lines: [],
         offsets: this._addOffsets ? [] : undefined,
         done: this._done,
-        bodyFunctionOffsets: this._addOffsets ? [] : undefined,
+        functionBodyOffsets: this._addOffsets ? [] : undefined,
       }
     }
     if (linesReady === this._lines.length) {
@@ -803,12 +804,12 @@ export class WasmDisassembler {
         lines: this._lines,
         offsets: this._addOffsets ? this._offsets : undefined,
         done: this._done,
-        bodyFunctionOffsets: this._addOffsets ? this._bodyFunctionOffsets : undefined,
+        functionBodyOffsets: this._addOffsets ? this._functionBodyOffsets : undefined,
       };
       this._lines = [];
       if (this._addOffsets) {
         this._offsets = [];
-        this._bodyFunctionOffsets = [];
+        this._functionBodyOffsets = [];
       }
       return result;
     }
@@ -816,7 +817,7 @@ export class WasmDisassembler {
       lines: this._lines.splice(0, linesReady),
       offsets: this._addOffsets ? this._offsets.splice(0, linesReady) : undefined,
       done: false,
-      bodyFunctionOffsets: this._addOffsets ? this._bodyFunctionOffsets : undefined,
+      functionBodyOffsets: this._addOffsets ? this._functionBodyOffsets : undefined,
     };
     if (this._backrefLabels) {
       this._backrefLabels.forEach((backrefLabel) => {


### PR DESCRIPTION
In this PR, getResult would return also the code section offsets as an array of 2 elements [beginCodeSectionOffset, endCodeSectionOffset]. From that, we can detect possible breakable line/bytecode offset in WAT.

TODO: in the follow-up PR, we would return an array of array of 2 elements such as
[[beginFunctionBody1Offset, endFunctionBody1Offset], [beginFunctionBody2Offset, endFunctionBody2Offset], ...] to avoid detecting function header as breakable line/offset