### PR TITLE
[wabt-compatibility] Change memory text syntax

### DIFF
--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -901,7 +901,7 @@ export class WasmDisassembler {
           var memoryName = this._nameResolver.getMemoryName(this._memoryCount++, false);
           this.appendBuffer(`  (memory ${memoryName} `);
           if (memoryInfo.shared) {
-            this.appendBuffer(`(shared ${limitsToString(memoryInfo.limits)})`);
+            this.appendBuffer(`${limitsToString(memoryInfo.limits)} shared`);
           } else {
             this.appendBuffer(limitsToString(memoryInfo.limits));
           }
@@ -964,7 +964,7 @@ export class WasmDisassembler {
               var memoryName = this._nameResolver.getMemoryName(this._memoryCount++, false);
               this.appendBuffer(` (memory ${memoryName} `);
               if (memoryImportInfo.shared) {
-                this.appendBuffer(`(shared ${limitsToString(memoryImportInfo.limits)})`);
+                this.appendBuffer(`${limitsToString(memoryImportInfo.limits)} shared`);
               } else {
                 this.appendBuffer(limitsToString(memoryImportInfo.limits));
               }

--- a/test/atomic.0.wasm.out
+++ b/test/atomic.0.wasm.out
@@ -8,7 +8,7 @@
   (type $type6 (func (param i32 i64) (result i64)))
   (type $type7 (func (param i32 i32 i32) (result i32)))
   (type $type8 (func (param i32 i64 i64) (result i64)))
-  (memory $memory0 (shared 1 1))
+  (memory $memory0 1 1 shared)
   (export "init" (func $func0))
   (export "i32.atomic.load" (func $func1))
   (export "i64.atomic.load" (func $func2))

--- a/test/atomic.1.wasm.out
+++ b/test/atomic.1.wasm.out
@@ -3,7 +3,7 @@
   (type $type1 (func (param i32 i32) (result i32)))
   (type $type2 (func (param i32 i64 i64) (result i32)))
   (type $type3 (func (param i32 i32 i64) (result i32)))
-  (memory $memory0 (shared 1 1))
+  (memory $memory0 1 1 shared)
   (export "init" (func $func0))
   (export "atomic.notify" (func $func1))
   (export "i64.atomic.wait" (func $func2))

--- a/test/threads.0.wasm.out
+++ b/test/threads.0.wasm.out
@@ -1,7 +1,7 @@
 (module
   (type $type0 (func (param i32) (result i32)))
   (type $type1 (func (param i32)))
-  (import "env" "memory" (memory $memory0 (shared 1 1)))
+  (import "env" "memory" (memory $memory0 1 1 shared))
   (export "tryLockMutex" (func $func0))
   (export "lockMutex" (func $func1))
   (export "unlockMutex" (func $func2))

--- a/wabt-compatibility.spec.ts
+++ b/wabt-compatibility.spec.ts
@@ -35,15 +35,12 @@ const INCOMPATIBLE_FILE_NAMES = [
   "threads.0.wasm.out",
 ];
 
-// These two below arrays are used to select corresponding feature flags for corresponding files.
-const FEATURE_FILE_NAMES = [
-  "atomic.1.wasm.out",
-];
-const FEATURE_FLAGS_FOR_FILE = [
-  {
+// This dict is used to select corresponding feature flags for corresponding files.
+const FEATURE_FLAGS_FOR_FILES = {
+  'atomic.1.wasm.out': {
     'threads': true,
   },
-];
+};
 
 // Run wabt over .out files.
 readdirSync(TEST_FOLDER)
@@ -52,8 +49,7 @@ readdirSync(TEST_FOLDER)
     test(`wabt ${fileName}`, () => {
       const filePath = join(TEST_FOLDER, fileName);
       let data = new Uint8Array(readFileSync(filePath));
-      const index = FEATURE_FILE_NAMES.indexOf(fileName);
-      const feature = index === -1 ? {} : FEATURE_FLAGS_FOR_FILE[index];
+      const feature = FEATURE_FLAGS_FOR_FILES[fileName] || {};
       expect(parseWat(fileName, data, feature)).toBeDefined();
     });
   });

--- a/wabt-compatibility.spec.ts
+++ b/wabt-compatibility.spec.ts
@@ -20,9 +20,8 @@ const { parseWat } = require("wabt")();
 
 const TEST_FOLDER = "./test";
 
-const INCOMPATIBLE_FILES = [
+const INCOMPATIBLE_FILE_NAMES = [
   "atomic.0.wasm.out",
-  "atomic.1.wasm.out",
   "conversion_sat.wasm.out",
   "memory_bulk.0.wasm.out",
   "ref_types.0.wasm.out",
@@ -36,14 +35,26 @@ const INCOMPATIBLE_FILES = [
   "threads.0.wasm.out",
 ];
 
+// These two below arrays are used to select corresponding feature flags for corresponding files.
+const FEATURE_FILE_NAMES = [
+  "atomic.1.wasm.out",
+];
+const FEATURE_FLAGS_FOR_FILE = [
+  {
+    'threads': true,
+  },
+];
+
 // Run wabt over .out files.
 readdirSync(TEST_FOLDER)
-  .filter(fileName => extname(fileName) === ".out" && INCOMPATIBLE_FILES.indexOf(fileName) === -1)
+  .filter(fileName => extname(fileName) === ".out" && INCOMPATIBLE_FILE_NAMES.indexOf(fileName) === -1)
   .forEach(fileName => {
     test(`wabt ${fileName}`, () => {
       const filePath = join(TEST_FOLDER, fileName);
       let data = new Uint8Array(readFileSync(filePath));
-      expect(parseWat(fileName, data)).toBeDefined();
+      const index = FEATURE_FILE_NAMES.indexOf(fileName);
+      const feature = index === -1 ? {} : FEATURE_FLAGS_FOR_FILE[index];
+      expect(parseWat(fileName, data, feature)).toBeDefined();
     });
   });
 


### PR DESCRIPTION
According to https://github.com/WebAssembly/threads/pull/74, memory text syntax has changed.

Also, wabt need 'threads' flags to run atomic operators

Bug: https://github.com/wasdk/wasmparser/issues/33