### PR TITLE
Fix up paths in binaries / examples

### DIFF
--- a/disassemble-wasm.js
+++ b/disassemble-wasm.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-var wasmparser = require('./dist/WasmParser.js');
-var wasmdis = require('./dist/WasmDis.js');
+var wasmparser = require('./dist/cjs/WasmParser.js');
+var wasmdis = require('./dist/cjs/WasmDis.js');
 var fs = require('fs');
 
 var wasmPath = process.argv[2];

--- a/examples/disassemble-wasm-1.js
+++ b/examples/disassemble-wasm-1.js
@@ -18,8 +18,8 @@
 // all available entries from the imcomplete data.
 // See also ../disassemble-wasm.js file.
 
-var wasmparser = require('../dist/WasmParser.js');
-var wasmdis = require('../dist/WasmDis.js');
+var wasmparser = require('../dist/cjs/WasmParser.js');
+var wasmdis = require('../dist/cjs/WasmDis.js');
 var fs = require('fs');
 
 var wasmPath = process.argv[2];

--- a/examples/disassemble-wasm-2.js
+++ b/examples/disassemble-wasm-2.js
@@ -16,8 +16,8 @@
 
 // Demo of the function names usage that are read from the name section.
 
-var wasmparser = require('../dist/WasmParser.js');
-var wasmdis = require('../dist/WasmDis.js');
+var wasmparser = require('../dist/cjs/WasmParser.js');
+var wasmdis = require('../dist/cjs/WasmDis.js');
 var fs = require('fs');
 
 var wasmPath = process.argv[2];

--- a/examples/dump-section.js
+++ b/examples/dump-section.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var wasmparser = require('../dist/WasmParser.js');
+var wasmparser = require('../dist/cjs/WasmParser.js');
 var fs = require('fs');
 
 var wasmPath = process.argv[2];

--- a/examples/print_imports_exports.js
+++ b/examples/print_imports_exports.js
@@ -4,9 +4,9 @@
 // Utility that prints WebAssembly module function imports/exports.
 
 var fs = require('fs');
-var WasmParserTransform = require('../dist/WasmParserTransform.js');
+var WasmParserTransform = require('../dist/cjs/WasmParserTransform.js');
 var ParserTransform = WasmParserTransform.BinaryReaderTransform;
-var WasmParser = require('../dist/WasmParser.js');
+var WasmParser = require('../dist/cjs/WasmParser.js');
 var BinaryReaderState = WasmParser.BinaryReaderState;
 var bytesToString = WasmParser.bytesToString;
 var ExternalKind = WasmParser.ExternalKind;

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "disassemble-wasm": "./disassemble-wasm.js"
   },
   "scripts": {
-    "test": "jest",
     "build": "concurrently \"npm:build:cjs\" \"npm:build:esm\"",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --target es5",
-    "build:esm": "tsc --module esnext --moduleResolution node --outDir dist/esm --target esnext"
+    "build:esm": "tsc --module esnext --moduleResolution node --outDir dist/esm --target esnext",
+    "prepare": "npm run build",
+    "test": "jest"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Drive-by: Run `build` script as part of the `prepare` step.