### PR TITLE
[wabt-compatibility] bulk memory

### DIFF
--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -743,11 +743,18 @@ export class WasmDisassembler {
         this.appendBuffer(` ${operator.lineIndex}`);
         break;
       case OperatorCode.memory_init:
-      case OperatorCode.table_init:
       case OperatorCode.data_drop:
       case OperatorCode.elem_drop:
         this.appendBuffer(` ${operator.segmentIndex}`);
         break;
+      case OperatorCode.table_set:
+      case OperatorCode.table_get:
+      case OperatorCode.table_fill:
+        {
+          let tableName = this._nameResolver.getTableName(operator.tableIndex, true);
+          this.appendBuffer(` ${tableName}`);
+          break;
+        }
       case OperatorCode.table_copy:
         {	
           // Table index might be omitted by default 0.
@@ -767,15 +774,7 @@ export class WasmDisassembler {
           let tableName = this._nameResolver.getTableName(operator.tableIndex, true);	
           this.appendBuffer(` ${operator.segmentIndex} ${tableName}`);	
           break;	
-        }         
-      case OperatorCode.table_set:
-      case OperatorCode.table_get:
-      case OperatorCode.table_fill:
-        {
-          let tableName = this._nameResolver.getTableName(operator.tableIndex, true);
-          this.appendBuffer(` ${tableName}`);
-          break;
-        }
+        }           
     }
   }
   private printImportSource(info: IImportEntry): void {

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -748,6 +748,26 @@ export class WasmDisassembler {
       case OperatorCode.elem_drop:
         this.appendBuffer(` ${operator.segmentIndex}`);
         break;
+      case OperatorCode.table_copy:
+        {	
+          // Table index might be omitted by default 0.
+          if (operator.tableIndex === 0 && operator.destinationIndex === 0) break;
+          let tableName = this._nameResolver.getTableName(operator.tableIndex, true);	
+          let destinationName = this._nameResolver.getTableName(operator.destinationIndex, true);	
+          this.appendBuffer(` ${destinationName} ${tableName}`);	
+          break;	
+        }	
+      case OperatorCode.table_init:
+        {
+          // Table index might be omitted by default 0.	
+          if (operator.tableIndex === 0) {
+            this.appendBuffer(` ${operator.segmentIndex}`);
+            break;
+          }
+          let tableName = this._nameResolver.getTableName(operator.tableIndex, true);	
+          this.appendBuffer(` ${operator.segmentIndex} ${tableName}`);	
+          break;	
+        }         
       case OperatorCode.table_set:
       case OperatorCode.table_get:
       case OperatorCode.table_fill:

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -757,7 +757,7 @@ export class WasmDisassembler {
         }
       case OperatorCode.table_copy:
         {	
-          // Table index might be omitted by default 0.
+          // Table index might be omitted and defaults to 0.
           if (operator.tableIndex === 0 && operator.destinationIndex === 0) break;
           let tableName = this._nameResolver.getTableName(operator.tableIndex, true);	
           let destinationName = this._nameResolver.getTableName(operator.destinationIndex, true);	
@@ -766,7 +766,7 @@ export class WasmDisassembler {
         }	
       case OperatorCode.table_init:
         {
-          // Table index might be omitted by default 0.	
+          // Table index might be omitted and defaults to 0.
           if (operator.tableIndex === 0) {
             this.appendBuffer(` ${operator.segmentIndex}`);
             break;

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -743,6 +743,7 @@ export class WasmDisassembler {
         this.appendBuffer(` ${operator.lineIndex}`);
         break;
       case OperatorCode.memory_init:
+      case OperatorCode.table_init:
       case OperatorCode.data_drop:
       case OperatorCode.elem_drop:
         this.appendBuffer(` ${operator.segmentIndex}`);
@@ -753,19 +754,6 @@ export class WasmDisassembler {
         {
           let tableName = this._nameResolver.getTableName(operator.tableIndex, true);
           this.appendBuffer(` ${tableName}`);
-          break;
-        }
-      case OperatorCode.table_copy:
-        {
-          let tableName = this._nameResolver.getTableName(operator.tableIndex, true);
-          let destinationName = this._nameResolver.getTableName(operator.destinationIndex, true);
-          this.appendBuffer(` ${destinationName} ${tableName}`);
-          break;
-        }
-      case OperatorCode.table_init:
-        {
-          let tableName = this._nameResolver.getTableName(operator.tableIndex, true);
-          this.appendBuffer(` ${operator.segmentIndex} ${tableName}`);
           break;
         }
     }

--- a/test/memory_bulk.0.wasm.out
+++ b/test/memory_bulk.0.wasm.out
@@ -21,12 +21,12 @@
     i32.const 0
     i32.const 0
     i32.const 0
-    table.init 0 $table0
+    table.init 0
     elem.drop 0
     i32.const 0
     i32.const 0
     i32.const 0
-    table.copy $table0 $table0
+    table.copy
   )
   (func $func1
   )

--- a/wabt-compatibility.spec.ts
+++ b/wabt-compatibility.spec.ts
@@ -21,7 +21,6 @@ const { parseWat } = require("wabt")();
 const TEST_FOLDER = "./test";
 
 const INCOMPATIBLE_FILE_NAMES = [
-  "memory_bulk.0.wasm.out",
   "spec.wasm.out",
 ];
 
@@ -50,6 +49,9 @@ const FEATURE_FLAGS_FOR_FILES = {
   },
   "simd.wasm.out": {
     'simd': true,
+  },
+  "memory_bulk.0.wasm.out": {
+    'bulk_memory': true,
   },
 };
 


### PR DESCRIPTION
According to https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md, instructions as table.init, table.copy has changed.

Bug: https://github.com/wasdk/wasmparser/issues/33