### PR TITLE
chore(package): add files to make source maps work

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 *~
 /examples
 /node_modules
-/src
 /test
 .editorconfig
 .travis.yml


### PR DESCRIPTION
For the source maps that we generate for both the `esm` as well
as the `cjs` target, we need to include the `src/*.ts` files as
well, otherwise the sourcemaps don't work when pulling from npm.