### PR TITLE
fix: make `dist/esm` output ES2015 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "concurrently \"npm:build:cjs\" \"npm:build:esm\"",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs --target es5",
-    "build:esm": "tsc --module esnext --moduleResolution node --outDir dist/esm --target esnext",
+    "build:esm": "tsc --module es2015 --moduleResolution node --outDir dist/esm --target es2015",
     "prepare": "npm run build",
     "test": "jest"
   },


### PR DESCRIPTION
This is to ensure that all tools that can deal with ES modules can also deal with the `dist/esm` output (I noticed this because `rollup` started to break with nullish coalescing that I used in `src/WasmDis.ts`).