### PR TITLE
fix: `grow_memory` -> `memory.grow`

### DIFF
--- a/src/WasmParser.ts
+++ b/src/WasmParser.ts
@@ -554,7 +554,7 @@ export const OperatorCodeNames = [
   "i64.store16",
   "i64.store32",
   "current_memory",
-  "grow_memory",
+  "memory.grow",
   "i32.const",
   "i64.const",
   "f32.const",

--- a/test/br.wast.0.wasm.out
+++ b/test/br.wast.0.wasm.out
@@ -484,7 +484,7 @@
     block $label0 (result i32)
       i32.const 40
       br $label0
-      grow_memory
+      memory.grow
     end $label0
   )
   (func $func53 (result i32)

--- a/test/br_table.wast.0.wasm.out
+++ b/test/br_table.wast.0.wasm.out
@@ -662,7 +662,7 @@
       i32.const 40
       i32.const 0
       br_table $label0
-      grow_memory
+      memory.grow
     end $label0
   )
   (func $func60 (param $var0 i32) (result i32)

--- a/test/imports.wast.98.wasm.out
+++ b/test/imports.wast.98.wasm.out
@@ -3,6 +3,6 @@
   (export "grow" (func $func0))
   (func $func0 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )

--- a/test/linking.wast.20.wasm.out
+++ b/test/linking.wast.20.wasm.out
@@ -3,6 +3,6 @@
   (export "grow" (func $func0))
   (func $func0 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )

--- a/test/malloc.wasm.out
+++ b/test/malloc.wasm.out
@@ -13133,6 +13133,6 @@
   )
   (func $func23 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )

--- a/test/memory_trap.wast.0.wasm.out
+++ b/test/memory_trap.wast.0.wasm.out
@@ -23,6 +23,6 @@
   )
   (func $func3 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )

--- a/test/nop.wast.0.wasm.out
+++ b/test/nop.wast.0.wasm.out
@@ -408,7 +408,7 @@
   (func $func47 (param $var0 i32) (result i32)
     local.get $var0
     nop
-    grow_memory
+    memory.grow
   )
   (func $func48 (param $var0 i32) (result i32)
     nop
@@ -416,6 +416,6 @@
     local.get $var0
     nop
     nop
-    grow_memory
+    memory.grow
   )
 )

--- a/test/resizing.wast.0.wasm.out
+++ b/test/resizing.wast.0.wasm.out
@@ -26,7 +26,7 @@
   )
   (func $func4 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
   (func $func5 (result i32)
     current_memory

--- a/test/resizing.wast.1.wasm.out
+++ b/test/resizing.wast.1.wasm.out
@@ -3,6 +3,6 @@
   (export "grow" (func $func0))
   (func $func0 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )

--- a/test/resizing.wast.2.wasm.out
+++ b/test/resizing.wast.2.wasm.out
@@ -3,6 +3,6 @@
   (export "grow" (func $func0))
   (func $func0 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )

--- a/test/return.wast.0.wasm.out
+++ b/test/return.wast.0.wasm.out
@@ -411,6 +411,6 @@
   (func $func54 (result i32)
     i32.const 40
     return
-    grow_memory
+    memory.grow
   )
 )

--- a/test/spec.wasm.out
+++ b/test/spec.wasm.out
@@ -1426,7 +1426,7 @@
     block $label0 (result i32)
       i32.const 40
       br $label0
-      grow_memory
+      memory.grow
     end $label0
   )
   (func $func53 (result i32)
@@ -2247,7 +2247,7 @@
     block $label0 (result i32)
       i32.const 40
       br $label0
-      grow_memory
+      memory.grow
     end $label0
   )
   (func $func53 (result i32)
@@ -3879,7 +3879,7 @@
       i32.const 40
       i32.const 0
       br_table $label0
-      grow_memory
+      memory.grow
     end $label0
   )
   (func $func60 (param $var0 i32) (result i32)
@@ -5809,7 +5809,7 @@
       i32.const 40
       i32.const 0
       br_table $label0
-      grow_memory
+      memory.grow
     end $label0
   )
   (func $func60 (param $var0 i32) (result i32)
@@ -19599,7 +19599,7 @@
   )
   (func $func3 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -19627,7 +19627,7 @@
   )
   (func $func3 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -19804,7 +19804,7 @@
   )
   (func $func4 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
   (func $func5 (result i32)
     current_memory
@@ -19815,7 +19815,7 @@
   (export "grow" (func $func0))
   (func $func0 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -19823,7 +19823,7 @@
   (export "grow" (func $func0))
   (func $func0 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -19854,7 +19854,7 @@
   )
   (func $func4 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
   (func $func5 (result i32)
     current_memory
@@ -19865,7 +19865,7 @@
   (export "grow" (func $func0))
   (func $func0 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -19873,7 +19873,7 @@
   (export "grow" (func $func0))
   (func $func0 (param $var0 i32) (result i32)
     local.get $var0
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -20286,7 +20286,7 @@
   (func $func47 (param $var0 i32) (result i32)
     local.get $var0
     nop
-    grow_memory
+    memory.grow
   )
   (func $func48 (param $var0 i32) (result i32)
     nop
@@ -20294,7 +20294,7 @@
     local.get $var0
     nop
     nop
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -20707,7 +20707,7 @@
   (func $func47 (param $var0 i32) (result i32)
     local.get $var0
     nop
-    grow_memory
+    memory.grow
   )
   (func $func48 (param $var0 i32) (result i32)
     nop
@@ -20715,7 +20715,7 @@
     local.get $var0
     nop
     nop
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -21132,7 +21132,7 @@
   (func $func54 (result i32)
     i32.const 40
     return
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -21549,7 +21549,7 @@
   (func $func54 (result i32)
     i32.const 40
     return
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -36543,7 +36543,7 @@
   )
   (func $func54 (result i32)
     unreachable
-    grow_memory
+    memory.grow
   )
 )
 (module
@@ -37255,6 +37255,6 @@
   )
   (func $func54 (result i32)
     unreachable
-    grow_memory
+    memory.grow
   )
 )

--- a/test/unreachable.wast.0.wasm.out
+++ b/test/unreachable.wast.0.wasm.out
@@ -382,6 +382,6 @@
   )
   (func $func56 (result i32)
     unreachable
-    grow_memory
+    memory.grow
   )
 )


### PR DESCRIPTION
The operator isn't named `grow_memory` but `memory.grow` in the
latest WebAssembly specification. [^1]

[^1]: https://webassembly.github.io/spec/core/text/instructions.html