### PR TITLE
fix: rename atomic.notify and *.atomic.wait

### DIFF
--- a/src/WasmParser.ts
+++ b/src/WasmParser.ts
@@ -1029,9 +1029,9 @@ export const OperatorCodeNames = [
 });
 
 [
-  "atomic.notify",
-  "i32.atomic.wait",
-  "i64.atomic.wait",
+  "memory.atomic.notify",
+  "memory.atomic.wait32",
+  "memory.atomic.wait64",
   undefined,
   undefined,
   undefined,

--- a/test/atomic.1.wasm.out
+++ b/test/atomic.1.wasm.out
@@ -12,18 +12,18 @@
   (func $func1 (param $var0 i32) (param $var1 i32) (result i32)
     local.get $var0
     local.get $var1
-    atomic.notify
+    memory.atomic.notify
   )
   (func $func2 (param $var0 i32) (param $var1 i64) (param $var2 i64) (result i32)
     local.get $var0
     local.get $var1
     local.get $var2
-    i64.atomic.wait
+    memory.atomic.wait64
   )
   (func $func3 (param $var0 i32) (param $var1 i32) (param $var2 i64) (result i32)
     local.get $var0
     local.get $var1
     local.get $var2
-    i32.atomic.wait
+    memory.atomic.wait32
   )
 )

--- a/test/threads.0.wasm.out
+++ b/test/threads.0.wasm.out
@@ -19,7 +19,7 @@
         local.get $var0
         i32.const 1
         i64.const -1
-        i32.atomic.wait
+        memory.atomic.wait32
         drop
         br $label1
       end $label1
@@ -31,7 +31,7 @@
     i32.atomic.store
     local.get $var0
     i32.const 1
-    atomic.notify
+    memory.atomic.notify
     drop
   )
 )

--- a/wabt-compatibility.spec.ts
+++ b/wabt-compatibility.spec.ts
@@ -20,7 +20,11 @@ const { parseWat } = require("wabt")();
 
 const TEST_FOLDER = "./test";
 
-const INCOMPATIBLE_FILE_NAMES = ["spec.wasm.out"];
+const INCOMPATIBLE_FILE_NAMES = [
+  "atomic.1.wasm.out",
+  "spec.wasm.out",
+  "threads.0.wasm.out",
+];
 
 // This dict is used to select corresponding feature flags for corresponding files.
 const FEATURE_FLAGS_FOR_FILES = {


### PR DESCRIPTION
Temporarily disable the relevant wabt compatibility fixes until we can
upgrade to the latest wabt.js, which requires more changes.

Refs: WebAssembly/threads#149