### PR TITLE
fix: ignore unsupported "name" subsections

### DIFF
--- a/src/WasmParser.ts
+++ b/src/WasmParser.ts
@@ -1604,6 +1604,9 @@ export class BinaryReader {
     this._pos += length;
     return new Uint8Array(result); // making a clone of the data
   }
+  private skipBytes(length: number) {
+    this._pos += length;
+  }
   private hasStringBytes(): boolean {
     if (!this.hasVarIntBytes()) return false;
     var pos = this._pos;
@@ -1945,9 +1948,10 @@ export class BinaryReader {
         };
         break;
       default:
-        this.error = new Error(`Bad name entry type: ${type}`);
-        this.state = BinaryReaderState.ERROR;
-        return true;
+        // Skip this unknown name subsection (as per specification,
+        // custom section errors shouldn't cause Wasm parsing to fail).
+        this.skipBytes(payloadLength);
+        return this.read();
     }
     this.state = BinaryReaderState.NAME_SECTION_ENTRY;
     this.result = result;

--- a/test/WasmDis.test.ts
+++ b/test/WasmDis.test.ts
@@ -207,6 +207,39 @@ describe("NameSectionReader", () => {
     expect(nsr.getNameResolver.bind(nsr)).toThrowError();
   });
 
+  test("Wasm module with unsupported name subsection", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x08, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Unsupported 255 name subsection
+      0xff, // id
+      0x02, // size
+      0x42, // payload
+      0x42,
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const nsr = new NameSectionReader();
+    nsr.read(reader);
+    expect(nsr.hasValidNames()).toBe(false);
+  });
+
   test("Wasm module with function name", () => {
     const { buffer } = parseWat(
       `test.wat`,


### PR DESCRIPTION
According to the WebAssembly specification, custom sections shouldn't
cause parsing to fail, and so we shouldn't error out because of an
unsupported subsection in the "name" custom section. This will make
the library more robust wrt. additions of more custom names.

Bug: https://crbug.com/1137335