### PR TITLE
feat: support some extended name subsections

### DIFF
--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -46,6 +46,10 @@ import {
   NULL_FUNCTION_INDEX,
   isTypeIndex,
   ILocalNameEntry,
+  ITypeNameEntry,
+  ITableNameEntry,
+  IMemoryNameEntry,
+  IGlobalNameEntry,
 } from "./WasmParser.js";
 
 const NAME_SECTION_NAME = "name";
@@ -343,68 +347,6 @@ class DevToolsExportMetadata implements IExportMetadata {
 
   public getTableExportNames(index: number) {
     return this._tableExportNames[index] ?? EMPTY_STRING_ARRAY;
-  }
-}
-
-export class DevToolsNameResolver extends DefaultNameResolver {
-  private readonly _functionNames: string[];
-  private readonly _localNames: string[][];
-  private readonly _memoryNames: string[];
-  private readonly _tableNames: string[];
-  private readonly _globalNames: string[];
-
-  constructor(
-    functionNames: string[],
-    localNames: string[][],
-    memoryNames: string[],
-    tableNames: string[],
-    globalNames: string[]
-  ) {
-    super();
-    this._functionNames = functionNames;
-    this._localNames = localNames;
-    this._memoryNames = memoryNames;
-    this._tableNames = tableNames;
-    this._globalNames = globalNames;
-  }
-
-  public getTableName(index: number, isRef: boolean): string {
-    const name = this._tableNames[index];
-    if (!name) return super.getTableName(index, isRef);
-    return isRef ? `$${name}` : `$${name} (;${index};)`;
-  }
-
-  public getMemoryName(index: number, isRef: boolean): string {
-    const name = this._memoryNames[index];
-    if (!name) return super.getMemoryName(index, isRef);
-    return isRef ? `$${name}` : `$${name} (;${index};)`;
-  }
-
-  public getGlobalName(index: number, isRef: boolean): string {
-    const name = this._globalNames[index];
-    if (!name) return super.getGlobalName(index, isRef);
-    return isRef ? `$${name}` : `$${name} (;${index};)`;
-  }
-
-  public getFunctionName(
-    index: number,
-    isImport: boolean,
-    isRef: boolean
-  ): string {
-    const name = this._functionNames[index];
-    if (!name) return super.getFunctionName(index, isImport, isRef);
-    return isRef ? `$${name}` : `$${name} (;${index};)`;
-  }
-
-  public getVariableName(
-    funcIndex: number,
-    index: number,
-    isRef: boolean
-  ): string {
-    const name =
-      this._localNames[funcIndex] && this._localNames[funcIndex][index];
-    if (!name) return super.getVariableName(funcIndex, index, isRef);
-    return isRef ? `$${name}` : `$${name} (;${index};)`;
   }
 }
 
@@ -1428,22 +1370,69 @@ export class WasmDisassembler {
 const UNKNOWN_FUNCTION_PREFIX = "unknown";
 
 class NameSectionNameResolver extends DefaultNameResolver {
-  private _names: string[];
-  private _localNames: string[][];
+  protected readonly _functionNames: string[];
+  protected readonly _localNames: string[][];
+  protected readonly _typeNames: string[];
+  protected readonly _tableNames: string[];
+  protected readonly _memoryNames: string[];
+  protected readonly _globalNames: string[];
 
-  constructor(names: string[], localNames: string[][]) {
+  constructor(
+    functionNames: string[],
+    localNames: string[][],
+    typeNames: string[],
+    tableNames: string[],
+    memoryNames: string[],
+    globalNames: string[]
+  ) {
     super();
-    this._names = names;
+    this._functionNames = functionNames;
     this._localNames = localNames;
+    this._typeNames = typeNames;
+    this._tableNames = tableNames;
+    this._memoryNames = memoryNames;
+    this._globalNames = globalNames;
   }
 
-  getFunctionName(index: number, isImport: boolean, isRef: boolean): string {
-    const name = this._names[index];
+  public getTypeName(index: number, isRef: boolean): string {
+    const name = this._typeNames[index];
+    if (!name) return super.getTypeName(index, isRef);
+    return isRef ? `$${name}` : `$${name} (;${index};)`;
+  }
+
+  public getTableName(index: number, isRef: boolean): string {
+    const name = this._tableNames[index];
+    if (!name) return super.getTableName(index, isRef);
+    return isRef ? `$${name}` : `$${name} (;${index};)`;
+  }
+
+  public getMemoryName(index: number, isRef: boolean): string {
+    const name = this._memoryNames[index];
+    if (!name) return super.getMemoryName(index, isRef);
+    return isRef ? `$${name}` : `$${name} (;${index};)`;
+  }
+
+  public getGlobalName(index: number, isRef: boolean): string {
+    const name = this._globalNames[index];
+    if (!name) return super.getGlobalName(index, isRef);
+    return isRef ? `$${name}` : `$${name} (;${index};)`;
+  }
+
+  public getFunctionName(
+    index: number,
+    isImport: boolean,
+    isRef: boolean
+  ): string {
+    const name = this._functionNames[index];
     if (!name) return `$${UNKNOWN_FUNCTION_PREFIX}${index}`;
     return isRef ? `$${name}` : `$${name} (;${index};)`;
   }
 
-  getVariableName(funcIndex: number, index: number, isRef: boolean): string {
+  public getVariableName(
+    funcIndex: number,
+    index: number,
+    isRef: boolean
+  ): string {
     const name =
       this._localNames[funcIndex] && this._localNames[funcIndex][index];
     if (!name) return super.getVariableName(funcIndex, index, isRef);
@@ -1452,21 +1441,16 @@ class NameSectionNameResolver extends DefaultNameResolver {
 }
 
 export class NameSectionReader {
-  private _done: boolean;
-  private _functionsCount: number;
-  private _functionImportsCount: number;
-  private _functionNames: string[];
-  private _functionLocalNames: string[][];
-  private _hasNames: boolean;
-
-  constructor() {
-    this._done = false;
-    this._functionsCount = 0;
-    this._functionImportsCount = 0;
-    this._functionNames = null;
-    this._functionLocalNames = null;
-    this._hasNames = false;
-  }
+  private _done = false;
+  private _functionsCount = 0;
+  private _functionImportsCount = 0;
+  private _functionNames: string[] = null;
+  private _functionLocalNames: string[][] = null;
+  private _typeNames: string[] = null;
+  private _tableNames: string[] = null;
+  private _memoryNames: string[] = null;
+  private _globalNames: string[] = null;
+  private _hasNames = false;
 
   public read(reader: BinaryReader): boolean {
     if (this._done)
@@ -1489,6 +1473,10 @@ export class NameSectionReader {
           this._functionImportsCount = 0;
           this._functionNames = [];
           this._functionLocalNames = [];
+          this._typeNames = [];
+          this._tableNames = [];
+          this._memoryNames = [];
+          this._globalNames = [];
           this._hasNames = false;
           break;
         case BinaryReaderState.END_SECTION:
@@ -1518,22 +1506,44 @@ export class NameSectionReader {
           this._functionsCount++;
           break;
         case BinaryReaderState.NAME_SECTION_ENTRY:
-          var nameInfo = <INameEntry>reader.result;
+          const nameInfo = <INameEntry>reader.result;
           if (nameInfo.type === NameType.Function) {
-            var functionNameInfo = <IFunctionNameEntry>nameInfo;
-            functionNameInfo.names.forEach((naming: INaming) => {
-              this._functionNames[naming.index] = bytesToString(naming.name);
+            const { names } = <IFunctionNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
+              this._functionNames[index] = bytesToString(name);
             });
             this._hasNames = true;
           } else if (nameInfo.type === NameType.Local) {
-            var localNameInfo = <ILocalNameEntry>nameInfo;
-            localNameInfo.funcs.forEach((localName) => {
-              this._functionLocalNames[localName.index] = [];
-              localName.locals.forEach((naming: INaming) => {
-                this._functionLocalNames[localName.index][
-                  naming.index
-                ] = bytesToString(naming.name);
+            const { funcs } = <ILocalNameEntry>nameInfo;
+            funcs.forEach(({ index, locals }) => {
+              const localNames = (this._functionLocalNames[index] = []);
+              locals.forEach(({ index, name }) => {
+                localNames[index] = bytesToString(name);
               });
+            });
+            this._hasNames = true;
+          } else if (nameInfo.type === NameType.Type) {
+            const { names } = <ITypeNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
+              this._typeNames[index] = bytesToString(name);
+            });
+            this._hasNames = true;
+          } else if (nameInfo.type === NameType.Table) {
+            const { names } = <ITableNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
+              this._tableNames[index] = bytesToString(name);
+            });
+            this._hasNames = true;
+          } else if (nameInfo.type === NameType.Memory) {
+            const { names } = <IMemoryNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
+              this._memoryNames[index] = bytesToString(name);
+            });
+            this._hasNames = true;
+          } else if (nameInfo.type === NameType.Global) {
+            const { names } = <IGlobalNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
+              this._globalNames[index] = bytesToString(name);
             });
             this._hasNames = true;
           }
@@ -1575,7 +1585,44 @@ export class NameSectionReader {
       usedNameAt[name] = i;
     }
 
-    return new NameSectionNameResolver(functionNames, this._functionLocalNames);
+    return new NameSectionNameResolver(
+      functionNames,
+      this._functionLocalNames,
+      this._typeNames,
+      this._tableNames,
+      this._memoryNames,
+      this._globalNames
+    );
+  }
+}
+
+export class DevToolsNameResolver extends NameSectionNameResolver {
+  constructor(
+    functionNames: string[],
+    localNames: string[][],
+    typeNames: string[],
+    tableNames: string[],
+    memoryNames: string[],
+    globalNames: string[]
+  ) {
+    super(
+      functionNames,
+      localNames,
+      typeNames,
+      tableNames,
+      memoryNames,
+      globalNames
+    );
+  }
+
+  public getFunctionName(
+    index: number,
+    isImport: boolean,
+    isRef: boolean
+  ): string {
+    const name = this._functionNames[index];
+    if (!name) return isImport ? `$import${index}` : `$func${index}`;
+    return isRef ? `$${name}` : `$${name} (;${index};)`;
   }
 }
 
@@ -1589,6 +1636,7 @@ export class DevToolsNameGenerator {
   private _functionNames: string[] = null;
   private _functionLocalNames: string[][] = null;
   private _memoryNames: string[] = null;
+  private _typeNames: string[] = null;
   private _tableNames: string[] = null;
   private _globalNames: string[] = null;
 
@@ -1646,6 +1694,7 @@ export class DevToolsNameGenerator {
           this._functionNames = [];
           this._functionLocalNames = [];
           this._memoryNames = [];
+          this._typeNames = [];
           this._tableNames = [];
           this._globalNames = [];
           this._functionExportNames = [];
@@ -1716,26 +1765,54 @@ export class DevToolsNameGenerator {
           }
           break;
         case BinaryReaderState.NAME_SECTION_ENTRY:
-          var nameInfo = <INameEntry>reader.result;
+          const nameInfo = <INameEntry>reader.result;
           if (nameInfo.type === NameType.Function) {
-            var functionNameInfo = <IFunctionNameEntry>nameInfo;
-            functionNameInfo.names.forEach((naming: INaming) => {
+            const { names } = <IFunctionNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
               this._setName(
                 this._functionNames,
-                naming.index,
-                bytesToString(naming.name),
+                index,
+                bytesToString(name),
                 true
               );
             });
           } else if (nameInfo.type === NameType.Local) {
-            var localNameInfo = <ILocalNameEntry>nameInfo;
-            localNameInfo.funcs.forEach((localName) => {
-              this._functionLocalNames[localName.index] = [];
-              localName.locals.forEach((naming: INaming) => {
-                this._functionLocalNames[localName.index][
-                  naming.index
-                ] = bytesToString(naming.name);
+            const { funcs } = <ILocalNameEntry>nameInfo;
+            funcs.forEach(({ index, locals }) => {
+              const localNames = (this._functionLocalNames[index] = []);
+              locals.forEach(({ index, name }) => {
+                localNames[index] = bytesToString(name);
               });
+            });
+          } else if (nameInfo.type === NameType.Type) {
+            const { names } = <ITypeNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
+              this._setName(this._typeNames, index, bytesToString(name), true);
+            });
+          } else if (nameInfo.type === NameType.Table) {
+            const { names } = <ITableNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
+              this._setName(this._tableNames, index, bytesToString(name), true);
+            });
+          } else if (nameInfo.type === NameType.Memory) {
+            const { names } = <IMemoryNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
+              this._setName(
+                this._memoryNames,
+                index,
+                bytesToString(name),
+                true
+              );
+            });
+          } else if (nameInfo.type === NameType.Global) {
+            const { names } = <IGlobalNameEntry>nameInfo;
+            names.forEach(({ index, name }) => {
+              this._setName(
+                this._globalNames,
+                index,
+                bytesToString(name),
+                true
+              );
             });
           }
           break;
@@ -1818,8 +1895,9 @@ export class DevToolsNameGenerator {
     return new DevToolsNameResolver(
       this._functionNames,
       this._functionLocalNames,
-      this._memoryNames,
+      this._typeNames,
       this._tableNames,
+      this._memoryNames,
       this._globalNames
     );
   }

--- a/src/WasmParser.ts
+++ b/src/WasmParser.ts
@@ -1148,6 +1148,10 @@ export const enum NameType {
   Module = 0,
   Function = 1,
   Local = 2,
+  Type = 4,
+  Table = 5,
+  Memory = 6,
+  Global = 7,
 }
 export const enum BinaryReaderState {
   ERROR = -1,
@@ -1287,6 +1291,18 @@ export interface ILocalName {
 }
 export interface ILocalNameEntry extends INameEntry {
   funcs: ILocalName[];
+}
+export interface ITypeNameEntry extends INameEntry {
+  names: INaming[];
+}
+export interface ITableNameEntry extends INameEntry {
+  names: INaming[];
+}
+export interface IMemoryNameEntry extends INameEntry {
+  names: INaming[];
+}
+export interface IGlobalNameEntry extends INameEntry {
+  names: INaming[];
 }
 export interface ILinkingEntry {
   type: LinkingType;
@@ -1930,17 +1946,28 @@ export class BinaryReader {
       this._pos = pos;
       return false;
     }
-    var result: IModuleNameEntry | IFunctionNameEntry | ILocalNameEntry;
+    var result:
+      | IModuleNameEntry
+      | IFunctionNameEntry
+      | ILocalNameEntry
+      | ITypeNameEntry
+      | ITableNameEntry
+      | IMemoryNameEntry
+      | IGlobalNameEntry;
     switch (type) {
       case NameType.Module:
         result = {
-          type: type,
+          type,
           moduleName: this.readStringBytes(),
         };
         break;
       case NameType.Function:
+      case NameType.Type:
+      case NameType.Table:
+      case NameType.Memory:
+      case NameType.Global:
         result = {
-          type: type,
+          type,
           names: this.readNameMap(),
         };
         break;
@@ -1955,7 +1982,7 @@ export class BinaryReader {
           });
         }
         result = {
-          type: type,
+          type,
           funcs: funcs,
         };
         break;

--- a/test/WasmDis.test.ts
+++ b/test/WasmDis.test.ts
@@ -184,6 +184,186 @@ describe("DevToolsNameGenerator", () => {
     expect(nr.getFunctionName(0, false, true)).toBe("$__");
     expect(nr.getFunctionName(0, false, false)).toBe("$__ (;0;)");
   });
+
+  test("Wasm module with type names", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x0e, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Type names
+      0x04, // id
+      0x07, // size
+      0x02, // length
+      // Type 0 "6"
+      0x00,
+      0x01,
+      0x36,
+      // Type 1 "8"
+      0x01,
+      0x01,
+      0x38,
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const ng = new DevToolsNameGenerator();
+    expect(ng.read(reader)).toBe(true);
+    const nr = ng.getNameResolver();
+    expect(nr.getTypeName(0, true)).toBe("$6");
+    expect(nr.getTypeName(0, false)).toBe("$6 (;0;)");
+    expect(nr.getTypeName(1, true)).toBe("$8");
+    expect(nr.getTypeName(1, false)).toBe("$8 (;1;)");
+  });
+
+  test("Wasm module with table names", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x0b, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Table names
+      0x05, // id
+      0x04, // size
+      0x01, // length
+      // Table 5 "0"
+      0x05,
+      0x01,
+      0x30,
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const ng = new DevToolsNameGenerator();
+    expect(ng.read(reader)).toBe(true);
+    const nr = ng.getNameResolver();
+    expect(nr.getTableName(5, true)).toBe("$0");
+    expect(nr.getTableName(5, false)).toBe("$0 (;5;)");
+  });
+
+  test("Wasm module with memory names", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x11, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Memory names
+      0x06, // id
+      0x0a, // size
+      0x02, // length
+      // Memory 0 "123"
+      0x00,
+      0x03,
+      0x31,
+      0x32,
+      0x33,
+      // Memory 1 "42"
+      0x01,
+      0x02,
+      0x34,
+      0x32,
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const ng = new DevToolsNameGenerator();
+    expect(ng.read(reader)).toBe(true);
+    const nr = ng.getNameResolver();
+    expect(nr.getMemoryName(0, true)).toBe("$123");
+    expect(nr.getMemoryName(0, false)).toBe("$123 (;0;)");
+    expect(nr.getMemoryName(1, true)).toBe("$42");
+    expect(nr.getMemoryName(1, false)).toBe("$42 (;1;)");
+    expect(nr.getMemoryName(2, true)).toBe("$memory2");
+    expect(nr.getMemoryName(2, false)).toBe("$memory2");
+  });
+
+  test("Wasm module with global names", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x11, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Global names
+      0x07, // id
+      0x0a, // size
+      0x02, // length
+      // Global 1 "123"
+      0x01,
+      0x03,
+      0x31,
+      0x32,
+      0x33,
+      // Global 2 "42"
+      0x02,
+      0x02,
+      0x34,
+      0x32,
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const ng = new DevToolsNameGenerator();
+    expect(ng.read(reader)).toBe(true);
+    const nr = ng.getNameResolver();
+    expect(nr.getGlobalName(0, true)).toBe("$global0");
+    expect(nr.getGlobalName(0, false)).toBe("$global0");
+    expect(nr.getGlobalName(1, true)).toBe("$123");
+    expect(nr.getGlobalName(1, false)).toBe("$123 (;1;)");
+    expect(nr.getGlobalName(2, true)).toBe("$42");
+    expect(nr.getGlobalName(2, false)).toBe("$42 (;2;)");
+  });
 });
 
 describe("NameSectionReader", () => {
@@ -202,7 +382,7 @@ describe("NameSectionReader", () => {
     const reader = new BinaryReader();
     reader.setData(data.buffer, 0, data.byteLength);
     const nsr = new NameSectionReader();
-    nsr.read(reader);
+    expect(nsr.read(reader)).toBe(true);
     expect(nsr.hasValidNames()).toBe(false);
     expect(nsr.getNameResolver.bind(nsr)).toThrowError();
   });
@@ -220,7 +400,7 @@ describe("NameSectionReader", () => {
       0x00,
       // name section
       0x00, // id
-      0x08, // size
+      0x09, // size
       // 'name'
       0x04,
       0x6e,
@@ -236,7 +416,7 @@ describe("NameSectionReader", () => {
     const reader = new BinaryReader();
     reader.setData(data.buffer, 0, data.byteLength);
     const nsr = new NameSectionReader();
-    nsr.read(reader);
+    expect(nsr.read(reader)).toBe(true);
     expect(nsr.hasValidNames()).toBe(false);
   });
 
@@ -315,6 +495,202 @@ describe("NameSectionReader", () => {
     expect(nr.getVariableName(0, 0, false)).toBe("$x (;0;)");
     expect(nr.getVariableName(0, 1, true)).toBe("$y");
     expect(nr.getVariableName(0, 1, false)).toBe("$y (;1;)");
+  });
+
+  test("Wasm module with type names", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x0e, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Type names
+      0x04, // id
+      0x07, // size
+      0x02, // length
+      // Type 0 "0"
+      0x00,
+      0x01,
+      0x30,
+      // Type 1 "1"
+      0x01,
+      0x01,
+      0x31,
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const nsr = new NameSectionReader();
+    expect(nsr.read(reader)).toBe(true);
+    expect(nsr.hasValidNames()).toBe(true);
+    const nr = nsr.getNameResolver();
+    expect(nr.getTypeName(0, true)).toBe("$0");
+    expect(nr.getTypeName(0, false)).toBe("$0 (;0;)");
+    expect(nr.getTypeName(1, true)).toBe("$1");
+    expect(nr.getTypeName(1, false)).toBe("$1 (;1;)");
+  });
+
+  test("Wasm module with table names", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x11, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Table names
+      0x05, // id
+      0x0a, // size
+      0x03, // length
+      // Table 0 "5"
+      0x00,
+      0x01,
+      0x35,
+      // Table 5 "3"
+      0x05,
+      0x01,
+      0x33,
+      // Table 9 "1"
+      0x09,
+      0x01,
+      0x31,
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const nsr = new NameSectionReader();
+    expect(nsr.read(reader)).toBe(true);
+    expect(nsr.hasValidNames()).toBe(true);
+    const nr = nsr.getNameResolver();
+    expect(nr.getTableName(0, true)).toBe("$5");
+    expect(nr.getTableName(0, false)).toBe("$5 (;0;)");
+    expect(nr.getTableName(5, true)).toBe("$3");
+    expect(nr.getTableName(5, false)).toBe("$3 (;5;)");
+    expect(nr.getTableName(9, true)).toBe("$1");
+    expect(nr.getTableName(9, false)).toBe("$1 (;9;)");
+  });
+
+  test("Wasm module with memory names", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x11, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Memory names
+      0x06, // id
+      0x0a, // size
+      0x02, // length
+      // Memory 0 "123"
+      0x00,
+      0x03,
+      0x31,
+      0x32,
+      0x33,
+      // Memory 1 "42"
+      0x01,
+      0x02,
+      0x34,
+      0x32,
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const nsr = new NameSectionReader();
+    expect(nsr.read(reader)).toBe(true);
+    expect(nsr.hasValidNames()).toBe(true);
+    const nr = nsr.getNameResolver();
+    expect(nr.getMemoryName(0, true)).toBe("$123");
+    expect(nr.getMemoryName(0, false)).toBe("$123 (;0;)");
+    expect(nr.getMemoryName(1, true)).toBe("$42");
+    expect(nr.getMemoryName(1, false)).toBe("$42 (;1;)");
+    expect(nr.getMemoryName(2, true)).toBe("$memory2");
+    expect(nr.getMemoryName(2, false)).toBe("$memory2");
+  });
+
+  test("Wasm module with global names", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x11, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Global names
+      0x07, // id
+      0x0a, // size
+      0x02, // length
+      // Global 1 "123"
+      0x01,
+      0x03,
+      0x31,
+      0x32,
+      0x33,
+      // Global 2 "42"
+      0x02,
+      0x02,
+      0x34,
+      0x32,
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+    const nsr = new NameSectionReader();
+    expect(nsr.read(reader)).toBe(true);
+    expect(nsr.hasValidNames()).toBe(true);
+    const nr = nsr.getNameResolver();
+    expect(nr.getGlobalName(0, true)).toBe("$global0");
+    expect(nr.getGlobalName(0, false)).toBe("$global0");
+    expect(nr.getGlobalName(1, true)).toBe("$123");
+    expect(nr.getGlobalName(1, false)).toBe("$123 (;1;)");
+    expect(nr.getGlobalName(2, true)).toBe("$42");
+    expect(nr.getGlobalName(2, false)).toBe("$42 (;2;)");
   });
 });
 


### PR DESCRIPTION
This adds initial support for extended "name" subsections, including
type, table, memory, and global names. While the proposal is currently
at Stage 1 only, it's already being implemented in Binaryen and thus
in Emscripten as well as wabt, so it makes sense to support this early
on.

As a drive-by-fix, this also removes some of the code duplication that
we had in the `NameSectionNameResolver` and the `DevToolsNameResolver`
classes.

Bug: https://crbug.com/1137335
Proposal: https://github.com/WebAssembly/extended-name-section