### PR TITLE
feat: add support for WasmGC proposal

### DIFF
--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -19,12 +19,13 @@ import {
   IExportEntry,
   IMemoryAddress,
   ExternalKind,
-  IFunctionType,
+  ITypeEntry,
   IFunctionEntry,
   IFunctionInformation,
   IImportEntry,
   IOperatorInformation,
   Type,
+  TypeKind,
   OperatorCode,
   OperatorCodeNames,
   Int64,
@@ -42,12 +43,12 @@ import {
   INameEntry,
   NameType,
   IFunctionNameEntry,
-  isTypeIndex,
   ILocalNameEntry,
   ITypeNameEntry,
   ITableNameEntry,
   IMemoryNameEntry,
   IGlobalNameEntry,
+  IFieldNameEntry,
   ElementMode,
 } from "./WasmParser.js";
 
@@ -58,26 +59,6 @@ const INVALID_NAME_SYMBOLS_REGEX_GLOBAL = new RegExp(
   "g"
 );
 
-function typeToString(type: number): string {
-  switch (type) {
-    case Type.i32:
-      return "i32";
-    case Type.i64:
-      return "i64";
-    case Type.f32:
-      return "f32";
-    case Type.f64:
-      return "f64";
-    case Type.v128:
-      return "v128";
-    case Type.funcref:
-      return "funcref";
-    case Type.externref:
-      return "externref";
-    default:
-      throw new Error(`Unexpected type ${type}`);
-  }
-}
 function formatFloat32(n: number): string {
   if (n === 0) return 1 / n < 0 ? "-0.0" : "0.0";
   if (isFinite(n)) return n.toString();
@@ -252,10 +233,6 @@ function memoryAddressToString(
     return `align=${1 << address.flags}`;
   return `offset=${address.offset | 0} align=${1 << address.flags}`;
 }
-function globalTypeToString(type: IGlobalType): string {
-  const typeStr = typeToString(type.contentType);
-  return type.mutability ? `(mut ${typeStr})` : typeStr;
-}
 function limitsToString(limits: IResizableLimits): string {
   return (
     limits.initial + (limits.maximum !== undefined ? " " + limits.maximum : "")
@@ -291,6 +268,7 @@ export interface INameResolver {
   getElementName(index: number, isRef: boolean): string;
   getFunctionName(index: number, isImport: boolean, isRef: boolean): string;
   getVariableName(funcIndex: number, index: number, isRef: boolean): string;
+  getFieldName(typeIndex: number, index: number, isRef: boolean): string;
   getLabel(index: number): string;
 }
 export class DefaultNameResolver implements INameResolver {
@@ -322,6 +300,13 @@ export class DefaultNameResolver implements INameResolver {
     isRef: boolean
   ): string {
     return "$var" + index;
+  }
+  public getFieldName(
+    typeIndex: number,
+    index: number,
+    isRef: boolean
+  ): string {
+    return "$field" + index;
   }
   public getLabel(index: number): string {
     return "$label" + index;
@@ -395,6 +380,13 @@ export class NumericNameResolver implements INameResolver {
   ): string {
     return isRef ? "" + index : `(;${index};)`;
   }
+  public getFieldName(
+    typeIndex: number,
+    index: number,
+    isRef: boolean
+  ): string {
+    return isRef ? "" : index + `(;${index};)`;
+  }
   public getLabel(index: number): string {
     return null;
   }
@@ -423,7 +415,7 @@ export class WasmDisassembler {
   private _lines: Array<string>;
   private _offsets: Array<number>;
   private _buffer: string;
-  private _types: Array<IFunctionType>;
+  private _types: Array<ITypeEntry>;
   private _funcIndex: number;
   private _funcTypes: Array<number>;
   private _importCount: number;
@@ -544,14 +536,77 @@ export class WasmDisassembler {
       });
     }
   }
+  private typeIndexToString(typeIndex: number): string {
+    if (typeIndex >= 0) return this._nameResolver.getTypeName(typeIndex, true);
+    switch (typeIndex) {
+      case TypeKind.funcref:
+        return "func";
+      case TypeKind.externref:
+        return "extern";
+      case TypeKind.anyref:
+        return "any";
+      case TypeKind.eqref:
+        return "eq";
+      case TypeKind.i31ref:
+        return "i31";
+      case TypeKind.dataref:
+        return "data";
+    }
+  }
+  private typeToString(type: Type): string {
+    switch (type.kind) {
+      case TypeKind.i32:
+        return "i32";
+      case TypeKind.i64:
+        return "i64";
+      case TypeKind.f32:
+        return "f32";
+      case TypeKind.f64:
+        return "f64";
+      case TypeKind.v128:
+        return "v128";
+      case TypeKind.i8:
+        return "i8";
+      case TypeKind.i16:
+        return "i16";
+      case TypeKind.funcref:
+        return "funcref";
+      case TypeKind.externref:
+        return "externref";
+      case TypeKind.anyref:
+        return "anyref";
+      case TypeKind.eqref:
+        return "eqref";
+      case TypeKind.i31ref:
+        return "i31ref";
+      case TypeKind.dataref:
+        return "dataref";
+      case TypeKind.ref:
+        return `(ref ${this.typeIndexToString(type.index)})`;
+      case TypeKind.optref:
+        return `(ref null ${this.typeIndexToString(type.index)})`;
+      case TypeKind.rtt:
+        return `(rtt ${this.typeIndexToString(type.index)})`;
+      case TypeKind.rtt_d:
+        return `(rtt ${type.depth} ${this.typeIndexToString(type.index)})`;
+      default:
+        throw new Error(`Unexpected type ${JSON.stringify(type)}`);
+    }
+  }
+  private maybeMut(type: string, mutability: boolean): string {
+    return mutability ? `(mut ${type})` : type;
+  }
+  private globalTypeToString(type: IGlobalType): string {
+    const typeStr = this.typeToString(type.contentType);
+    return this.maybeMut(typeStr, !!type.mutability);
+  }
   private printFuncType(typeIndex: number): void {
     var type = this._types[typeIndex];
-    if (type.form !== Type.func) throw new Error("NYI other function form");
     if (type.params.length > 0) {
       this.appendBuffer(" (param");
       for (var i = 0; i < type.params.length; i++) {
         this.appendBuffer(" ");
-        this.appendBuffer(typeToString(type.params[i]));
+        this.appendBuffer(this.typeToString(type.params[i]));
       }
       this.appendBuffer(")");
     }
@@ -559,20 +614,39 @@ export class WasmDisassembler {
       this.appendBuffer(" (result");
       for (var i = 0; i < type.returns.length; i++) {
         this.appendBuffer(" ");
-        this.appendBuffer(typeToString(type.returns[i]));
+        this.appendBuffer(this.typeToString(type.returns[i]));
       }
       this.appendBuffer(")");
     }
   }
-  private printBlockType(type: number): void {
-    if (type === Type.empty_block_type) {
+  private printStructType(typeIndex: number): void {
+    var type = this._types[typeIndex];
+    if (type.fields.length === 0) return;
+    for (var i = 0; i < type.fields.length; i++) {
+      const fieldType = this.maybeMut(
+        this.typeToString(type.fields[i]),
+        type.mutabilities[i]
+      );
+      const fieldName = this._nameResolver.getFieldName(typeIndex, i, false);
+      this.appendBuffer(` (field ${fieldName} ${fieldType})`);
+    }
+  }
+  private printArrayType(typeIndex: number): void {
+    var type = this._types[typeIndex];
+    this.appendBuffer(" (field ");
+    this.appendBuffer(
+      this.maybeMut(this.typeToString(type.elementType), type.mutability)
+    );
+  }
+  private printBlockType(type: Type): void {
+    if (type.kind === TypeKind.empty_block_type) {
       return;
     }
-    if (isTypeIndex(type)) {
-      return this.printFuncType(type);
+    if (type.kind === TypeKind.unspecified) {
+      return this.printFuncType(type.index);
     }
     this.appendBuffer(" (result ");
-    this.appendBuffer(typeToString(type));
+    this.appendBuffer(this.typeToString(type));
     this.appendBuffer(")");
   }
   private printString(b: Uint8Array): void {
@@ -663,6 +737,11 @@ export class WasmDisassembler {
         break;
       case OperatorCode.br:
       case OperatorCode.br_if:
+      case OperatorCode.br_on_null:
+      case OperatorCode.br_on_cast:
+      case OperatorCode.br_on_func:
+      case OperatorCode.br_on_data:
+      case OperatorCode.br_on_i31:
         this.appendBuffer(" ");
         this.appendBuffer(this.useLabel(operator.brDepth));
         break;
@@ -673,16 +752,8 @@ export class WasmDisassembler {
         }
         break;
       case OperatorCode.ref_null:
-        switch (operator.refType) {
-          case Type.funcref:
-            this.appendBuffer(" func");
-            break;
-          case Type.externref:
-            this.appendBuffer(" extern");
-            break;
-          default:
-            throw new Error(`Unknown refedtype ${operator.refType}`);
-        }
+        this.appendBuffer(" ");
+        this.appendBuffer(this.typeIndexToString(operator.refType));
         break;
       case OperatorCode.call:
       case OperatorCode.return_call:
@@ -917,6 +988,34 @@ export class WasmDisassembler {
         this.appendBuffer(` ${elementName}`);
         break;
       }
+      case OperatorCode.struct_get:
+      case OperatorCode.struct_get_s:
+      case OperatorCode.struct_get_u:
+      case OperatorCode.struct_set: {
+        const refType = this._nameResolver.getTypeName(operator.refType, true);
+        const fieldName = this._nameResolver.getFieldName(
+          operator.refType,
+          operator.fieldIndex,
+          true
+        );
+        this.appendBuffer(` ${refType} ${fieldName}`);
+        break;
+      }
+      case OperatorCode.rtt_canon:
+      case OperatorCode.rtt_sub:
+      case OperatorCode.struct_new_default_with_rtt:
+      case OperatorCode.struct_new_with_rtt:
+      case OperatorCode.array_new_default_with_rtt:
+      case OperatorCode.array_new_with_rtt:
+      case OperatorCode.array_get:
+      case OperatorCode.array_get_s:
+      case OperatorCode.array_get_u:
+      case OperatorCode.array_set:
+      case OperatorCode.array_len: {
+        const refType = this._nameResolver.getTypeName(operator.refType, true);
+        this.appendBuffer(` ${refType}`);
+        break;
+      }
     }
   }
   private printImportSource(info: IImportEntry): void {
@@ -1079,7 +1178,7 @@ export class WasmDisassembler {
             }
           }
           this.appendBuffer(
-            ` ${limitsToString(tableInfo.limits)} ${typeToString(
+            ` ${limitsToString(tableInfo.limits)} ${this.typeToString(
               tableInfo.elementType
             )})`
           );
@@ -1172,7 +1271,9 @@ export class WasmDisassembler {
               }
               this.appendBuffer(` (import `);
               this.printImportSource(importInfo);
-              this.appendBuffer(`) ${globalTypeToString(globalImportInfo)})`);
+              this.appendBuffer(
+                `) ${this.globalTypeToString(globalImportInfo)})`
+              );
               break;
             case ExternalKind.Memory:
               var memoryImportInfo = <IMemoryType>importInfo.type;
@@ -1215,9 +1316,9 @@ export class WasmDisassembler {
               this.appendBuffer(` (import `);
               this.printImportSource(importInfo);
               this.appendBuffer(
-                `) ${limitsToString(tableImportInfo.limits)} ${typeToString(
-                  tableImportInfo.elementType
-                )})`
+                `) ${limitsToString(
+                  tableImportInfo.limits
+                )} ${this.typeToString(tableImportInfo.elementType)})`
               );
               break;
             default:
@@ -1256,7 +1357,9 @@ export class WasmDisassembler {
           break;
         case BinaryReaderState.ELEMENT_SECTION_ENTRY_BODY:
           const elementSegmentBody = <IElementSegmentBody>reader.result;
-          this.appendBuffer(` ${typeToString(elementSegmentBody.elementType)}`);
+          this.appendBuffer(
+            ` ${this.typeToString(elementSegmentBody.elementType)}`
+          );
           break;
         case BinaryReaderState.BEGIN_GLOBAL_SECTION_ENTRY:
           var globalInfo = <IGlobalVariable>reader.result;
@@ -1270,21 +1373,33 @@ export class WasmDisassembler {
               this.appendBuffer(` (export "${exportName}")`);
             }
           }
-          this.appendBuffer(` ${globalTypeToString(globalInfo.type)}`);
+          this.appendBuffer(` ${this.globalTypeToString(globalInfo.type)}`);
           break;
         case BinaryReaderState.END_GLOBAL_SECTION_ENTRY:
           this.appendBuffer(")");
           this.newLine();
           break;
         case BinaryReaderState.TYPE_SECTION_ENTRY:
-          var funcType = <IFunctionType>reader.result;
+          var typeEntry = <ITypeEntry>reader.result;
           var typeIndex = this._types.length;
-          this._types.push(funcType);
+          this._types.push(typeEntry);
           if (!this._skipTypes) {
             var typeName = this._nameResolver.getTypeName(typeIndex, false);
-            this.appendBuffer(`  (type ${typeName} (func`);
-            this.printFuncType(typeIndex);
-            this.appendBuffer("))");
+            if (typeEntry.form === TypeKind.func) {
+              this.appendBuffer(`  (type ${typeName} (func`);
+              this.printFuncType(typeIndex);
+              this.appendBuffer("))");
+            } else if (typeEntry.form === TypeKind.struct) {
+              this.appendBuffer(`  (type ${typeName} (struct`);
+              this.printStructType(typeIndex);
+              this.appendBuffer("))");
+            } else if (typeEntry.form === TypeKind.array) {
+              this.appendBuffer(`  (type ${typeName} (array`);
+              this.printArrayType(typeIndex);
+              this.appendBuffer("))");
+            } else {
+              throw new Error(`Unknown type form: ${typeEntry.form}`);
+            }
             this.newLine();
           }
           break;
@@ -1372,11 +1487,13 @@ export class WasmDisassembler {
               false
             );
             this.appendBuffer(
-              ` (param ${paramName} ${typeToString(type.params[i])})`
+              ` (param ${paramName} ${this.typeToString(type.params[i])})`
             );
           }
           for (var i = 0; i < type.returns.length; i++) {
-            this.appendBuffer(` (result ${typeToString(type.returns[i])})`);
+            this.appendBuffer(
+              ` (result ${this.typeToString(type.returns[i])})`
+            );
           }
           this.newLine();
           var localIndex = type.params.length;
@@ -1390,7 +1507,7 @@ export class WasmDisassembler {
                   false
                 );
                 this.appendBuffer(
-                  ` (local ${paramName} ${typeToString(l.type)})`
+                  ` (local ${paramName} ${this.typeToString(l.type)})`
                 );
               }
             }
@@ -1454,6 +1571,7 @@ class NameSectionNameResolver extends DefaultNameResolver {
   protected readonly _tableNames: string[];
   protected readonly _memoryNames: string[];
   protected readonly _globalNames: string[];
+  protected readonly _fieldNames: string[][];
 
   constructor(
     functionNames: string[],
@@ -1461,7 +1579,8 @@ class NameSectionNameResolver extends DefaultNameResolver {
     typeNames: string[],
     tableNames: string[],
     memoryNames: string[],
-    globalNames: string[]
+    globalNames: string[],
+    fieldNames: string[][]
   ) {
     super();
     this._functionNames = functionNames;
@@ -1470,6 +1589,7 @@ class NameSectionNameResolver extends DefaultNameResolver {
     this._tableNames = tableNames;
     this._memoryNames = memoryNames;
     this._globalNames = globalNames;
+    this._fieldNames = fieldNames;
   }
 
   public getTypeName(index: number, isRef: boolean): string {
@@ -1516,6 +1636,17 @@ class NameSectionNameResolver extends DefaultNameResolver {
     if (!name) return super.getVariableName(funcIndex, index, isRef);
     return isRef ? `$${name}` : `$${name} (;${index};)`;
   }
+
+  public getFieldName(
+    typeIndex: number,
+    index: number,
+    isRef: boolean
+  ): string {
+    const name =
+      this._fieldNames[typeIndex] && this._fieldNames[typeIndex][index];
+    if (!name) return super.getFieldName(typeIndex, index, isRef);
+    return isRef ? `$${name}` : `$${name} (;${index};)`;
+  }
 }
 
 export class NameSectionReader {
@@ -1528,6 +1659,7 @@ export class NameSectionReader {
   private _tableNames: string[] = null;
   private _memoryNames: string[] = null;
   private _globalNames: string[] = null;
+  private _fieldNames: string[][] = null;
   private _hasNames = false;
 
   public read(reader: BinaryReader): boolean {
@@ -1555,6 +1687,7 @@ export class NameSectionReader {
           this._tableNames = [];
           this._memoryNames = [];
           this._globalNames = [];
+          this._fieldNames = [];
           this._hasNames = false;
           break;
         case BinaryReaderState.END_SECTION:
@@ -1624,6 +1757,14 @@ export class NameSectionReader {
               this._globalNames[index] = bytesToString(name);
             });
             this._hasNames = true;
+          } else if (nameInfo.type === NameType.Field) {
+            const { types } = <IFieldNameEntry>nameInfo;
+            types.forEach(({ index, fields }) => {
+              const fieldNames = (this._fieldNames[index] = []);
+              fields.forEach(({ index, name }) => {
+                fieldNames[index] = bytesToString(name);
+              });
+            });
           }
           break;
         default:
@@ -1669,7 +1810,8 @@ export class NameSectionReader {
       this._typeNames,
       this._tableNames,
       this._memoryNames,
-      this._globalNames
+      this._globalNames,
+      this._fieldNames
     );
   }
 }
@@ -1681,7 +1823,8 @@ export class DevToolsNameResolver extends NameSectionNameResolver {
     typeNames: string[],
     tableNames: string[],
     memoryNames: string[],
-    globalNames: string[]
+    globalNames: string[],
+    fieldNames: string[][]
   ) {
     super(
       functionNames,
@@ -1689,7 +1832,8 @@ export class DevToolsNameResolver extends NameSectionNameResolver {
       typeNames,
       tableNames,
       memoryNames,
-      globalNames
+      globalNames,
+      fieldNames
     );
   }
 
@@ -1717,6 +1861,7 @@ export class DevToolsNameGenerator {
   private _typeNames: string[] = null;
   private _tableNames: string[] = null;
   private _globalNames: string[] = null;
+  private _fieldNames: string[][] = null;
 
   private _functionExportNames: string[][] = null;
   private _globalExportNames: string[][] = null;
@@ -1775,6 +1920,7 @@ export class DevToolsNameGenerator {
           this._typeNames = [];
           this._tableNames = [];
           this._globalNames = [];
+          this._fieldNames = [];
           this._functionExportNames = [];
           this._globalExportNames = [];
           this._memoryExportNames = [];
@@ -1892,6 +2038,14 @@ export class DevToolsNameGenerator {
                 true
               );
             });
+          } else if (nameInfo.type === NameType.Field) {
+            const { types } = <IFieldNameEntry>nameInfo;
+            types.forEach(({ index, fields }) => {
+              const fieldNames = (this._fieldNames[index] = []);
+              fields.forEach(({ index, name }) => {
+                fieldNames[index] = bytesToString(name);
+              });
+            });
           }
           break;
         case BinaryReaderState.EXPORT_SECTION_ENTRY:
@@ -1976,7 +2130,8 @@ export class DevToolsNameGenerator {
       this._typeNames,
       this._tableNames,
       this._memoryNames,
-      this._globalNames
+      this._globalNames,
+      this._fieldNames
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export {
   ISourceMappingURL,
   IStartEntry,
   IFunctionEntry,
-  IFunctionType,
+  ITypeEntry,
   ISectionInformation,
   ILocals,
   IFunctionInformation,

--- a/test/WasmDis.test.ts
+++ b/test/WasmDis.test.ts
@@ -909,3 +909,538 @@ describe("WasmDisassembler.getResult() without function code", () => {
     expect(result.lines).toEqual(expectedLinesWithTypes);
   });
 });
+
+describe("GC proposal support", () => {
+  // At the time of writing this test, there is no readily available tool
+  // to assemble the module from wat text, so we hard-code its binary
+  // contents here.
+  const module_bytes = [
+    0x00,
+    0x61,
+    0x73,
+    0x6d,
+    1,
+    0,
+    0,
+    0, // wasm magic
+
+    0x01, // type section
+    0x2c, // section length: 41
+    0x08, // number of types
+    // type  0:
+    0x5f, // struct
+    0x02, // field count
+    0x7f,
+    0x01, // mut i32
+    0x7e,
+    0x00, // i64
+    // type  1:
+    0x5f, // struct
+    0x02, // field count
+    0x7a,
+    0x01, // mut i8
+    0x79,
+    0x00, // i16
+    // type  2:
+    0x5f, // struct
+    0x02, // field count
+    0x7d,
+    0x01, // mut f32
+    0x7c,
+    0x00, // f64
+    // type  3:
+    0x5f, // struct
+    0x02, // field count
+    0x6c,
+    0x00,
+    0x01, // mut ref null 0
+    0x6a,
+    0x00, // i31ref
+    // type  4:
+    0x5f, // struct
+    0x03, // field count
+    0x6b,
+    0x01,
+    0x00, // ref 1
+    0x6d,
+    0x00, // eqref
+    0x67,
+    0x00, // dataref
+    // type  5:
+    0x5e, // array
+    0x7f,
+    0x01, // mut i32
+    // type  6:
+    0x5e, // array
+    0x7a,
+    0x01, // mut i8
+    // type  7:
+    0x60, // signature
+    0x00, // number of params
+    0x00, // number of results
+
+    0x03, // function section
+    0x06, // section length
+    0x05, // number of functions
+    0x07, // function 0: signature 7
+    0x07, // function 1: signature 7
+    0x07, // function 2: signature 7
+    0x07, // function 3: signature 7
+    0x07, // function 4: signature 7
+
+    /////////////////////////// CODE SECTION //////////////////////////
+    0x0a, // code section
+    0xd3,
+    0x01, // section length
+    0x05, // number of functions
+
+    0x50, // function 0: size
+    0x02, // number of locals
+    0x01,
+    0x6c,
+    0x00, // one local of type: optref 0
+    0x01,
+    0x6c,
+    0x01, // one local of type: optref 1
+    0x41,
+    0x2a, // i32.const: 42
+    0x42,
+    0x2b, // i64.const: 43
+    0xfb,
+    0x30,
+    0x00, // rtt.canon 0
+    0xfb,
+    0x01,
+    0x00, // struct.new_with_rtt 0
+    0x21,
+    0x00, // local.set 0
+    0x20,
+    0x00, // local.get 0
+    0xd3, // ref.as_non_null
+    0x41,
+    0x2c, // i32.const 44
+    0xfb,
+    0x06,
+    0x00,
+    0x00, // struct.set 0 0
+    0x20,
+    0x00, // local.get 0
+    0xfb,
+    0x30,
+    0x00, // rtt.canon 0
+    0xfb,
+    0x41, // ref.cast
+    0xfb,
+    0x03,
+    0x00,
+    0x01, // struct.get 0 1
+    0x1a, // drop
+    // ---
+    0xfb,
+    0x30,
+    0x01, // rtt.canon 1
+    0xfb,
+    0x31,
+    0x01, // rtt.sub 1
+    0xfb,
+    0x02,
+    0x01, // struct.new_default_with_rtt 1
+    0x21,
+    0x01, // local.set 1
+    0x20,
+    0x01, // local.get 1
+    0xfb,
+    0x04,
+    0x01,
+    0x00, // struct.get_s 1 0
+    0x1a, // drop
+    0x20,
+    0x01, // local.get 1
+    0xfb,
+    0x05,
+    0x01,
+    0x01, // struct.get_u 1 1
+    0x1a, // drop
+    // ---
+    0x20,
+    0x01, // local.get 1
+    0xd0,
+    0x01, // ref.null 1
+    0xd5, // ref.eq
+    0x1a, // drop
+    0xd0,
+    0x6d, // ref.null eq
+    0xfb,
+    0x30,
+    0x00, // rtt.canon 0
+    0xfb,
+    0x40, // ref.test
+    0x1a, // drop
+    0x0b, // end
+
+    0x0d, // function 1: size
+    0x00, // number of locals
+    0x41,
+    0x7f, // i32.const -1
+    0xfb,
+    0x20, // i31.new
+    0xfb,
+    0x21, // i31.get_s
+    0xfb,
+    0x20, // i31.new
+    0xfb,
+    0x22, // i31.get_u
+    0x1a, // drop
+    0x0b, // end
+
+    0x0f, // function 2: size
+    0x01, // number of locals
+    0x01,
+    0x6c,
+    0x70, // one local of type: ref null func
+    0xd2,
+    0x01, // ref.func $func1
+    0x21,
+    0x00, // local.set 0
+    0x20,
+    0x00, // local.get 0
+    0x14, // call_ref
+    0x20,
+    0x00, // local.get 0
+    0x15, // return_call_ref
+    0x0b, // end
+
+    0x2b, // function 3: size
+    0x00, // number of locals
+    0x02,
+    0x40, // block <void>
+    0xd0,
+    0x6e, // ref.null any
+    0xd4,
+    0x00, // br_on_null 0
+    0xfb,
+    0x30,
+    0x00, // rtt.canon 0
+    0xfb,
+    0x42,
+    0x00, // br_on_cast 0
+    0xfb,
+    0x60,
+    0x00, // br_on_func 0
+    0xfb,
+    0x61,
+    0x00, // br_on_data 0
+    0xfb,
+    0x62,
+    0x00, // br_on_i31 0
+    0xfb,
+    0x58, // ref.as_func
+    0xfb,
+    0x59, // ref.as_data
+    0xfb,
+    0x5a, // ref.as_i31
+    0xfb,
+    0x50, // ref.is_func
+    0x1a, // drop
+    0xd0,
+    0x6e, // ref.null any
+    0xfb,
+    0x51, // ref.is_data
+    0x1a, // drop
+    0xd0,
+    0x6e, // ref.null any
+    0xfb,
+    0x52, // ref.is_i31
+    0x1a, // drop
+    0x0b, // end (block)
+    0x0b, // end
+
+    0x36, // function 4: size
+    0x02, // number of locals
+    0x01,
+    0x6c,
+    0x05, // one local of type: optref 5
+    0x01,
+    0x6c,
+    0x06, // one local of type: optref 6
+    0x41,
+    0x01, // i32.const 1 (default value)
+    0x41,
+    0x02, // i32.const 2 (length)
+    0xfb,
+    0x30,
+    0x05, // rtt.canon 5
+    0xfb,
+    0x11,
+    0x05, // array.new_with_rtt 5
+    0x22,
+    0x00, // local.tee 0
+    0x20,
+    0x00, // local.get 0
+    0x41,
+    0x01, // i32.const 1 (index)
+    0xfb,
+    0x13,
+    0x05, // array.get 5 (reuse as index)
+    0x41,
+    0x02, // i32.const 2 (value)
+    0xfb,
+    0x16,
+    0x05, // array.set 5
+    0xfb,
+    0x17,
+    0x05, // array.len 5
+    0xfb,
+    0x30,
+    0x06, // rtt.canon 6
+    0xfb,
+    0x12,
+    0x06, // array.new_default_with_rtt 6
+    0x22,
+    0x01, // local.tee 1
+    0x20,
+    0x01, // local.get 1
+    0x41,
+    0x01, // i32.const 1 (index)
+    0xfb,
+    0x14,
+    0x06, // array.get_s 6 (reuse as index)
+    0xfb,
+    0x15,
+    0x06, // array.get_u 7
+    0x1a, // drop
+    0x0b, // end
+
+    /////////////////////////// NAME SECTION //////////////////////////
+    0x00, // name section
+    0x60, // section length
+    0x04, // length of "name"
+    0x6e,
+    0x61,
+    0x6d,
+    0x65, // "name"
+
+    0x04, // "type names" subsection
+    0x3e, // length of subsection
+    0x07, // number of entries
+    0x00, // type index
+    0x07, // name length
+    0x73,
+    0x74,
+    0x72,
+    0x75,
+    0x63,
+    0x74,
+    0x41, // "structA"
+    0x01, // type index
+    0x07, // name length
+    0x73,
+    0x74,
+    0x72,
+    0x75,
+    0x63,
+    0x74,
+    0x42, // "structB"
+    0x02, // type index
+    0x07, // name length
+    0x73,
+    0x74,
+    0x72,
+    0x75,
+    0x63,
+    0x74,
+    0x43, // "structC"
+    0x03, // type index
+    0x07, // name length
+    0x73,
+    0x74,
+    0x72,
+    0x75,
+    0x63,
+    0x74,
+    0x44, // "structD"
+    0x04, // type index
+    0x07, // name length
+    0x73,
+    0x74,
+    0x72,
+    0x75,
+    0x63,
+    0x74,
+    0x45, // "structE"
+    0x05, // type index
+    0x06, // name length
+    0x61,
+    0x72,
+    0x72,
+    0x61,
+    0x79,
+    0x41, // "arrayA"
+    0x06, // type index
+    0x06, // name length
+    0x61,
+    0x72,
+    0x72,
+    0x61,
+    0x79,
+    0x42, // "arrayB"
+
+    0x0a, // "field names" subsection
+    0x19, // length of subsection
+    0x02, // number of types
+    0x00, // for type 0
+    0x02, // number of entries for type 0
+    0x00, // field index
+    0x03, // length of "foo"
+    0x66,
+    0x6f,
+    0x6f, // "foo"
+    0x01, // field index
+    0x03, // length of "bar"
+    0x62,
+    0x61,
+    0x72, // "bar"
+    0x01, // for type 1
+    0x02, // number of entries for type 1
+    0x00, // field index
+    0x03, // length of "baz"
+    0x62,
+    0x61,
+    0x7a, // "baz"
+    0x01, // field index
+    0x03, // length of "qux"
+    0x71,
+    0x75,
+    0x78, // "qux"
+  ];
+
+  const expectedLines = [
+    "(module",
+    "  (type $structA (;0;) (struct (field $foo (;0;) (mut i32)) (field $bar (;1;) i64)))",
+    "  (type $structB (;1;) (struct (field $baz (;0;) (mut i8)) (field $qux (;1;) i16)))",
+    "  (type $structC (;2;) (struct (field $field0 (mut f32)) (field $field1 f64)))",
+    "  (type $structD (;3;) (struct (field $field0 (mut (ref null $structA))) (field $field1 i31ref)))",
+    "  (type $structE (;4;) (struct (field $field0 (ref $structB)) (field $field1 eqref) (field $field2 dataref)))",
+    "  (type $arrayA (;5;) (array (field (mut i32)))",
+    "  (type $arrayB (;6;) (array (field (mut i8)))",
+    "  (type $type7 (func))",
+    "  (func $unknown0",
+    "    (local $var0 (ref null $structA)) (local $var1 (ref null $structB))",
+    "    i32.const 42",
+    "    i64.const 43",
+    "    rtt.canon $structA",
+    "    struct.new_with_rtt $structA",
+    "    local.set $var0",
+    "    local.get $var0",
+    "    ref.as_non_null",
+    "    i32.const 44",
+    "    struct.set $structA $foo",
+    "    local.get $var0",
+    "    rtt.canon $structA",
+    "    ref.cast",
+    "    struct.get $structA $bar",
+    "    drop",
+    "    rtt.canon $structB",
+    "    rtt.sub $structB",
+    "    struct.new_default_with_rtt $structB",
+    "    local.set $var1",
+    "    local.get $var1",
+    "    struct.get_s $structB $baz",
+    "    drop",
+    "    local.get $var1",
+    "    struct.get_u $structB $qux",
+    "    drop",
+    "    local.get $var1",
+    "    ref.null $structB",
+    "    ref.eq",
+    "    drop",
+    "    ref.null eq",
+    "    rtt.canon $structA",
+    "    ref.test",
+    "    drop",
+    "  )",
+    "  (func $unknown1",
+    "    i32.const -1",
+    "    i31.new",
+    "    i31.get_s",
+    "    i31.new",
+    "    i31.get_u",
+    "    drop",
+    "  )",
+    "  (func $unknown2",
+    "    (local $var0 funcref)",
+    "    ref.func $unknown1",
+    "    local.set $var0",
+    "    local.get $var0",
+    "    call_ref",
+    "    local.get $var0",
+    "    return_call_ref",
+    "  )",
+    "  (func $unknown3",
+    "    block $label0",
+    "      ref.null any",
+    "      br_on_null $label0",
+    "      rtt.canon $structA",
+    "      br_on_cast $label0",
+    "      br_on_func $label0",
+    "      br_on_data $label0",
+    "      br_on_i31 $label0",
+    "      ref.as_func",
+    "      ref.as_data",
+    "      ref.as_i31",
+    "      ref.is_func",
+    "      drop",
+    "      ref.null any",
+    "      ref.is_data",
+    "      drop",
+    "      ref.null any",
+    "      ref.is_i31",
+    "      drop",
+    "    end $label0",
+    "  )",
+    "  (func $unknown4",
+    "    (local $var0 (ref null $arrayA)) (local $var1 (ref null $arrayB))",
+    "    i32.const 1",
+    "    i32.const 2",
+    "    rtt.canon $arrayA",
+    "    array.new_with_rtt $arrayA",
+    "    local.tee $var0",
+    "    local.get $var0",
+    "    i32.const 1",
+    "    array.get $arrayA",
+    "    i32.const 2",
+    "    array.set $arrayA",
+    "    array.len $arrayA",
+    "    rtt.canon $arrayB",
+    "    array.new_default_with_rtt $arrayB",
+    "    local.tee $var1",
+    "    local.get $var1",
+    "    i32.const 1",
+    "    array.get_s $arrayB",
+    "    array.get_u $arrayB",
+    "    drop",
+    "  )",
+    ")",
+  ];
+
+  test("GC disassembly", async () => {
+    var data = new Uint8Array(module_bytes);
+
+    var parser = new BinaryReader();
+    parser.setData(data.buffer, 0, data.length);
+    var namesReader = new NameSectionReader();
+    namesReader.read(parser);
+
+    var parser = new BinaryReader();
+    parser.setData(data.buffer, 0, data.length);
+    var dis = new WasmDisassembler();
+    dis.skipTypes = false;
+
+    if (namesReader.hasValidNames())
+      dis.nameResolver = namesReader.getNameResolver();
+
+    dis.disassembleChunk(parser);
+    const result = dis.getResult();
+    expect(result.lines).toEqual(expectedLines);
+  });
+});

--- a/test/WasmParser.test.ts
+++ b/test/WasmParser.test.ts
@@ -23,6 +23,7 @@ import {
   OperatorCode,
   SectionCode,
   Type,
+  TypeKind,
 } from "../src/WasmParser";
 
 describe("BinaryReader", () => {
@@ -504,7 +505,7 @@ describe("BinaryReader", () => {
     expect(reader.state).toBe(BinaryReaderState.INIT_EXPRESSION_OPERATOR);
     expect(reader.result).toMatchObject({
       code: OperatorCode.ref_null,
-      refType: Type.funcref,
+      refType: TypeKind.funcref,
     });
     expect(reader.read()).toBe(true);
     expect(reader.state).toBe(BinaryReaderState.INIT_EXPRESSION_OPERATOR);
@@ -569,7 +570,7 @@ describe("BinaryReader", () => {
     expect(reader.state).toBe(BinaryReaderState.INIT_EXPRESSION_OPERATOR);
     expect(reader.result).toMatchObject({
       code: OperatorCode.ref_null,
-      refType: Type.externref,
+      refType: TypeKind.externref,
     });
     expect(reader.read()).toBe(true);
     expect(reader.state).toBe(BinaryReaderState.INIT_EXPRESSION_OPERATOR);
@@ -582,7 +583,7 @@ describe("BinaryReader", () => {
     expect(reader.state).toBe(BinaryReaderState.INIT_EXPRESSION_OPERATOR);
     expect(reader.result).toMatchObject({
       code: OperatorCode.ref_null,
-      refType: Type.externref,
+      refType: TypeKind.externref,
     });
     expect(reader.read()).toBe(true);
     expect(reader.state).toBe(BinaryReaderState.INIT_EXPRESSION_OPERATOR);
@@ -595,7 +596,7 @@ describe("BinaryReader", () => {
     expect(reader.state).toBe(BinaryReaderState.INIT_EXPRESSION_OPERATOR);
     expect(reader.result).toMatchObject({
       code: OperatorCode.ref_null,
-      refType: Type.externref,
+      refType: TypeKind.externref,
     });
     expect(reader.read()).toBe(true);
     expect(reader.state).toBe(BinaryReaderState.INIT_EXPRESSION_OPERATOR);
@@ -1014,5 +1015,29 @@ describe("BinaryReader", () => {
     expect(reader.read()).toBe(true);
     expect(reader.state).toBe(BinaryReaderState.END_WASM);
     expect(reader.read()).toBe(false);
+  });
+});
+
+describe("decoding unit tests", () => {
+  test("decodeHeapType supports s33 values", () => {
+    function testCase(expected, data) {
+      const bytes = new Uint8Array(data);
+      const reader = new BinaryReader();
+      reader.setData(bytes, 0, bytes.byteLength);
+      // Access private method for testing using array notation.
+      expect(reader["readHeapType"]()).toEqual(expected);
+    }
+    testCase(0, [0x00]);
+    testCase(1, [0x01]);
+    testCase(1, [0x81, 0x80, 0x80, 0x80, 0x80]);
+    testCase(-1, [0x7f]);
+    testCase(-1, [0xff, 0x7f]);
+    testCase(-1, [0xff, 0xff, 0xff, 0xff, 0x7f]);
+    testCase(127, [0xff, 0x00]);
+    testCase(-127, [0x81, 0x7f]);
+    testCase(1023, [0xff, 0x07]);
+    testCase(4294967295, [0xff, 0xff, 0xff, 0xff, 0x0f]);
+    testCase(-2147483648, [0x80, 0x80, 0x80, 0x80, 0x78]);
+    testCase(-4294967296, [0x80, 0x80, 0x80, 0x80, 0x70]);
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: IFunctionType is replaced by the more general ITypeEntry.
BREAKING CHANGE: Type is now a class; the former enum is now called TypeKind. Several other interfaces now use Type instances instead of numbers to describe types.