### PR TITLE
fix: missing initializer in devtools name generator for exceptions

### DIFF
--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -2030,6 +2030,7 @@ export class DevToolsNameGenerator {
 
           this._functionNames = [];
           this._functionLocalNames = [];
+          this._eventNames = [];
           this._memoryNames = [];
           this._typeNames = [];
           this._tableNames = [];

--- a/test/WasmDis.test.ts
+++ b/test/WasmDis.test.ts
@@ -372,6 +372,28 @@ describe("DevToolsNameGenerator", () => {
     expect(nr.getGlobalName(2, true)).toBe("$42");
     expect(nr.getGlobalName(2, false)).toBe("$42 (;2;)");
   });
+
+  test("Wasm module with event names", async () => {
+    const { parseWat } = await wabtPromise;
+    const { buffer } = parseWat(
+      `test.wat`,
+      `(module
+        (event (type 1))
+        (event (type 2))
+        (export "ex" (event 0))
+       )`,
+      { exceptions: true }
+    ).toBinary({ write_debug_names: true });
+    const reader = new BinaryReader();
+    reader.setData(buffer.buffer, 0, buffer.byteLength);
+    const ng = new DevToolsNameGenerator();
+    ng.read(reader);
+    const nr = ng.getNameResolver();
+    expect(nr.getEventName(0, true)).toBe("$ex");
+    expect(nr.getEventName(0, false)).toBe("$ex (;0;)");
+    expect(nr.getEventName(1, true)).toBe("$event1");
+    expect(nr.getEventName(1, false)).toBe("$event1");
+  });
 });
 
 describe("NameSectionReader", () => {


### PR DESCRIPTION
Without this fix, standalone disassembly worked, but attempting to disassemble modules with exceptions in DevTools resulted in:
`TypeError: Cannot read property '0' of null`.