### PR TITLE
feat: implement more instructions

### DIFF
--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -759,6 +759,7 @@ export class WasmDisassembler {
       case OperatorCode.br:
       case OperatorCode.br_if:
       case OperatorCode.br_on_null:
+      case OperatorCode.br_on_non_null:
       case OperatorCode.br_on_cast:
       case OperatorCode.br_on_cast_fail:
       case OperatorCode.br_on_func:

--- a/src/WasmDis.ts
+++ b/src/WasmDis.ts
@@ -760,9 +760,13 @@ export class WasmDisassembler {
       case OperatorCode.br_if:
       case OperatorCode.br_on_null:
       case OperatorCode.br_on_cast:
+      case OperatorCode.br_on_cast_fail:
       case OperatorCode.br_on_func:
+      case OperatorCode.br_on_non_func:
       case OperatorCode.br_on_data:
+      case OperatorCode.br_on_non_data:
       case OperatorCode.br_on_i31:
+      case OperatorCode.br_on_non_i31:
         this.appendBuffer(" ");
         this.appendBuffer(this.useLabel(operator.brDepth));
         break;
@@ -806,6 +810,11 @@ export class WasmDisassembler {
       case OperatorCode.return_call_indirect:
         this.printFuncType(operator.typeIndex);
         break;
+      case OperatorCode.select_with_type: {
+        const selectType = this.typeToString(operator.selectType);
+        this.appendBuffer(` ${selectType}`);
+        break;
+      }
       case OperatorCode.local_get:
       case OperatorCode.local_set:
       case OperatorCode.local_tee:
@@ -1040,6 +1049,7 @@ export class WasmDisassembler {
       }
       case OperatorCode.rtt_canon:
       case OperatorCode.rtt_sub:
+      case OperatorCode.rtt_fresh_sub:
       case OperatorCode.struct_new_default_with_rtt:
       case OperatorCode.struct_new_with_rtt:
       case OperatorCode.array_new_default_with_rtt:
@@ -1052,6 +1062,11 @@ export class WasmDisassembler {
         const refType = this._nameResolver.getTypeName(operator.refType, true);
         this.appendBuffer(` ${refType}`);
         break;
+      }
+      case OperatorCode.array_copy: {
+        const dstType = this._nameResolver.getTypeName(operator.refType, true);
+        const srcType = this._nameResolver.getTypeName(operator.srcType, true);
+        this.appendBuffer(` ${dstType} ${srcType}`);
       }
     }
   }

--- a/src/WasmParser.ts
+++ b/src/WasmParser.ts
@@ -261,6 +261,7 @@ export const enum OperatorCode {
   ref_as_non_null = 0xd3,
   br_on_null = 0xd4,
   ref_eq = 0xd5,
+  br_on_non_null = 0xd6,
 
   atomic_notify = 0xfe00,
   i32_atomic_wait = 0xfe01,
@@ -821,7 +822,7 @@ export const OperatorCodeNames = [
   "ref.as_non_null",
   "br_on_null",
   "ref.eq",
-  undefined,
+  "br_on_non_null",
   undefined,
   undefined,
   undefined,
@@ -3146,6 +3147,7 @@ export class BinaryReader {
         case OperatorCode.br:
         case OperatorCode.br_if:
         case OperatorCode.br_on_null:
+        case OperatorCode.br_on_non_null:
           brDepth = this.readVarUint32() >>> 0;
           break;
         case OperatorCode.br_table:

--- a/src/WasmParser.ts
+++ b/src/WasmParser.ts
@@ -61,6 +61,7 @@ export const enum OperatorCode {
   catch_all = 0x19,
   drop = 0x1a,
   select = 0x1b,
+  select_with_type = 0x1c,
   local_get = 0x20,
   local_set = 0x21,
   local_tee = 0x22,
@@ -580,14 +581,17 @@ export const enum OperatorCode {
   array_get_u = 0xfb15,
   array_set = 0xfb16,
   array_len = 0xfb17,
+  array_copy = 0xfb18, // Non-standard experiment in V8.
   i31_new = 0xfb20,
   i31_get_s = 0xfb21,
   i31_get_u = 0xfb22,
   rtt_canon = 0xfb30,
   rtt_sub = 0xfb31,
+  rtt_fresh_sub = 0xfb32, // Non-standard experiment in V8.
   ref_test = 0xfb40,
   ref_cast = 0xfb41,
   br_on_cast = 0xfb42,
+  br_on_cast_fail = 0xfb43,
   ref_is_func = 0xfb50,
   ref_is_data = 0xfb51,
   ref_is_i31 = 0xfb52,
@@ -597,6 +601,9 @@ export const enum OperatorCode {
   br_on_func = 0xfb60,
   br_on_data = 0xfb61,
   br_on_i31 = 0xfb62,
+  br_on_non_func = 0xfb63,
+  br_on_non_data = 0xfb64,
+  br_on_non_i31 = 0xfb65,
 }
 
 export const OperatorCodeNames = [
@@ -628,7 +635,7 @@ export const OperatorCodeNames = [
   "catch_all",
   "drop",
   "select",
-  undefined,
+  "select", // with types.
   undefined,
   undefined,
   undefined,
@@ -1239,14 +1246,17 @@ OperatorCodeNames[0xfb14] = "array.get_s";
 OperatorCodeNames[0xfb15] = "array.get_u";
 OperatorCodeNames[0xfb16] = "array.set";
 OperatorCodeNames[0xfb17] = "array.len";
+OperatorCodeNames[0xfb18] = "array.copy";
 OperatorCodeNames[0xfb20] = "i31.new";
 OperatorCodeNames[0xfb21] = "i31.get_s";
 OperatorCodeNames[0xfb22] = "i31.get_u";
 OperatorCodeNames[0xfb30] = "rtt.canon";
 OperatorCodeNames[0xfb31] = "rtt.sub";
+OperatorCodeNames[0xfb32] = "rtt.fresh_sub";
 OperatorCodeNames[0xfb40] = "ref.test";
 OperatorCodeNames[0xfb41] = "ref.cast";
 OperatorCodeNames[0xfb42] = "br_on_cast";
+OperatorCodeNames[0xfb43] = "br_on_cast_fail";
 OperatorCodeNames[0xfb50] = "ref.is_func";
 OperatorCodeNames[0xfb51] = "ref.is_data";
 OperatorCodeNames[0xfb52] = "ref.is_i31";
@@ -1256,6 +1266,9 @@ OperatorCodeNames[0xfb5a] = "ref.as_i31";
 OperatorCodeNames[0xfb60] = "br_on_func";
 OperatorCodeNames[0xfb61] = "br_on_data";
 OperatorCodeNames[0xfb62] = "br_on_i31";
+OperatorCodeNames[0xfb63] = "br_on_non_func";
+OperatorCodeNames[0xfb64] = "br_on_non_data";
+OperatorCodeNames[0xfb65] = "br_on_non_i31";
 
 export const enum ExternalKind {
   Function = 0,
@@ -1622,7 +1635,9 @@ export interface IMemoryAddress {
 export interface IOperatorInformation {
   code: OperatorCode;
   blockType?: Type;
+  selectType?: Type;
   refType?: number; // "HeapType" format, a.k.a. s33
+  srcType?: number; // "HeapType" format, a.k.a. s33
   brDepth?: number;
   brTable?: Array<number>;
   relativeDepth?: number;
@@ -2490,14 +2505,18 @@ export class BinaryReader {
     if (!this._eof && !this.hasBytes(MAX_CODE_OPERATOR_0XFB_SIZE)) {
       return false;
     }
-    var code, brDepth, refType, fieldIndex;
+    var code, brDepth, refType, srcType, fieldIndex;
 
     code = this._data[this._pos++] | 0xfb00;
     switch (code) {
       case OperatorCode.br_on_cast:
+      case OperatorCode.br_on_cast_fail:
       case OperatorCode.br_on_func:
+      case OperatorCode.br_on_non_func:
       case OperatorCode.br_on_data:
+      case OperatorCode.br_on_non_data:
       case OperatorCode.br_on_i31:
+      case OperatorCode.br_on_non_i31:
         brDepth = this.readVarUint32() >>> 0;
         break;
       case OperatorCode.array_get:
@@ -2511,7 +2530,12 @@ export class BinaryReader {
       case OperatorCode.struct_new_default_with_rtt:
       case OperatorCode.rtt_canon:
       case OperatorCode.rtt_sub:
+      case OperatorCode.rtt_fresh_sub:
         refType = this.readHeapType();
+        break;
+      case OperatorCode.array_copy:
+        refType = this.readHeapType();
+        srcType = this.readHeapType();
         break;
       case OperatorCode.struct_get:
       case OperatorCode.struct_get_s:
@@ -2543,6 +2567,7 @@ export class BinaryReader {
       code,
       blockType: undefined,
       refType,
+      srcType,
       brDepth,
       brTable: undefined,
       tableIndex: undefined,
@@ -2616,7 +2641,9 @@ export class BinaryReader {
     this.result = {
       code: code,
       blockType: undefined,
+      selectType: undefined,
       refType: undefined,
+      srcType: undefined,
       brDepth: undefined,
       brTable: undefined,
       funcIndex: undefined,
@@ -2901,7 +2928,9 @@ export class BinaryReader {
     this.result = {
       code: code,
       blockType: undefined,
+      selectType: undefined,
       refType: undefined,
+      srcType: undefined,
       brDepth: undefined,
       brTable: undefined,
       funcIndex: undefined,
@@ -3018,7 +3047,9 @@ export class BinaryReader {
     this.result = {
       code: code,
       blockType: undefined,
+      selectType: undefined,
       refType: undefined,
+      srcType: undefined,
       brDepth: undefined,
       brTable: undefined,
       funcIndex: undefined,
@@ -3067,6 +3098,7 @@ export class BinaryReader {
     }
     var code,
       blockType,
+      selectType,
       refType,
       brDepth,
       brTable,
@@ -3215,6 +3247,13 @@ export class BinaryReader {
             this._data.byteOffset
           ).getFloat64(this._pos, true);
           this._pos += 8;
+          break;
+        case OperatorCode.select_with_type:
+          const num_types = this.readVarInt32();
+          // Only 1 is a valid value currently.
+          if (num_types == 1) {
+            selectType = this.readType();
+          }
           break;
         case OperatorCode.prefix_0xfb:
           if (this.readCodeOperator_0xfb()) {
@@ -3392,7 +3431,9 @@ export class BinaryReader {
     this.result = {
       code,
       blockType,
+      selectType,
       refType,
+      srcType: undefined,
       brDepth,
       brTable,
       relativeDepth,

--- a/test/WasmDis.test.ts
+++ b/test/WasmDis.test.ts
@@ -1002,21 +1002,22 @@ describe("GC proposal support", () => {
     0x00, // number of results
 
     0x03, // function section
-    0x06, // section length
-    0x05, // number of functions
+    0x07, // section length
+    0x06, // number of functions
     0x07, // function 0: signature 7
     0x07, // function 1: signature 7
     0x07, // function 2: signature 7
     0x07, // function 3: signature 7
     0x07, // function 4: signature 7
+    0x07, // function 5: signature 7
 
     /////////////////////////// CODE SECTION //////////////////////////
     0x0a, // code section
-    0xd3,
-    0x01, // section length
-    0x05, // number of functions
+    0x83,
+    0x02, // section length
+    0x06, // number of functions
 
-    0x50, // function 0: size
+    0x53, // function 0: size
     0x02, // number of locals
     0x01,
     0x6c,
@@ -1064,6 +1065,9 @@ describe("GC proposal support", () => {
     0xfb,
     0x31,
     0x01, // rtt.sub 1
+    0xfb,
+    0x32,
+    0x01, // rtt.fresh_sub 1
     0xfb,
     0x02,
     0x01, // struct.new_default_with_rtt 1
@@ -1132,7 +1136,7 @@ describe("GC proposal support", () => {
     0x15, // return_call_ref
     0x0b, // end
 
-    0x2b, // function 3: size
+    0x37, // function 3: size
     0x00, // number of locals
     0x02,
     0x40, // block <void>
@@ -1147,14 +1151,26 @@ describe("GC proposal support", () => {
     0x42,
     0x00, // br_on_cast 0
     0xfb,
+    0x43,
+    0x00, // br_on_cast_fail 0
+    0xfb,
     0x60,
     0x00, // br_on_func 0
+    0xfb,
+    0x63,
+    0x00, // br_on_non_func 0
     0xfb,
     0x61,
     0x00, // br_on_data 0
     0xfb,
+    0x64,
+    0x00, // br_on_non_data 0
+    0xfb,
     0x62,
     0x00, // br_on_i31 0
+    0xfb,
+    0x65,
+    0x00, // br_on_non_i31 0
     0xfb,
     0x58, // ref.as_func
     0xfb,
@@ -1177,7 +1193,7 @@ describe("GC proposal support", () => {
     0x0b, // end (block)
     0x0b, // end
 
-    0x36, // function 4: size
+    0x44, // function 4: size
     0x02, // number of locals
     0x01,
     0x6c,
@@ -1230,6 +1246,40 @@ describe("GC proposal support", () => {
     0xfb,
     0x15,
     0x06, // array.get_u 7
+    0x1a, // drop
+    0x20,
+    0x00, // local.get 0
+    0x41,
+    0x00, // i32.const 0
+    0x20,
+    0x00, // local.get 0
+    0x41,
+    0x02, // i32.const 2
+    0x41,
+    0x01, // i32.const 1
+    0xfb,
+    0x18,
+    0x05,
+    0x05, // array.copy 5 5
+    0x0b, // end
+
+    0x12, // function 5: size
+    0x00, // number of locals
+    0xd0,
+    0x01, // ref.null 1
+    0xd0,
+    0x01, // ref.null 1
+    0x41,
+    0x01, // i32.const 1
+    0x41,
+    0x00, // i32.const 0
+    0x41,
+    0x01, // i32.const 1
+    0x1b, // select
+    0x1c,
+    0x01,
+    0x6b,
+    0x01, // select_with_type vec(ref(1))
     0x1a, // drop
     0x0b, // end
 
@@ -1362,8 +1412,10 @@ describe("GC proposal support", () => {
     "    ref.cast",
     "    struct.get $structA $bar",
     "    drop",
+    // ---
     "    rtt.canon $structB",
     "    rtt.sub $structB",
+    "    rtt.fresh_sub $structB",
     "    struct.new_default_with_rtt $structB",
     "    local.set $var1",
     "    local.get $var1",
@@ -1372,6 +1424,7 @@ describe("GC proposal support", () => {
     "    local.get $var1",
     "    struct.get_u $structB $qux",
     "    drop",
+    // ---
     "    local.get $var1",
     "    ref.null $structB",
     "    ref.eq",
@@ -1404,9 +1457,13 @@ describe("GC proposal support", () => {
     "      br_on_null $label0",
     "      rtt.canon $structA",
     "      br_on_cast $label0",
+    "      br_on_cast_fail $label0",
     "      br_on_func $label0",
+    "      br_on_non_func $label0",
     "      br_on_data $label0",
+    "      br_on_non_data $label0",
     "      br_on_i31 $label0",
+    "      br_on_non_i31 $label0",
     "      ref.as_func",
     "      ref.as_data",
     "      ref.as_i31",
@@ -1440,6 +1497,22 @@ describe("GC proposal support", () => {
     "    i32.const 1",
     "    array.get_s $arrayB",
     "    array.get_u $arrayB",
+    "    drop",
+    "    local.get $var0",
+    "    i32.const 0",
+    "    local.get $var0",
+    "    i32.const 2",
+    "    i32.const 1",
+    "    array.copy $arrayA $arrayA",
+    "  )",
+    "  (func $unknown5",
+    "    ref.null $structB",
+    "    ref.null $structB",
+    "    i32.const 1",
+    "    i32.const 0",
+    "    i32.const 1",
+    "    select",
+    "    select (ref $structB)",
     "    drop",
     "  )",
     ")",

--- a/test/WasmDis.test.ts
+++ b/test/WasmDis.test.ts
@@ -1013,7 +1013,7 @@ describe("GC proposal support", () => {
 
     /////////////////////////// CODE SECTION //////////////////////////
     0x0a, // code section
-    0x83,
+    0x85,
     0x02, // section length
     0x06, // number of functions
 
@@ -1136,7 +1136,7 @@ describe("GC proposal support", () => {
     0x15, // return_call_ref
     0x0b, // end
 
-    0x37, // function 3: size
+    0x39, // function 3: size
     0x00, // number of locals
     0x02,
     0x40, // block <void>
@@ -1144,6 +1144,8 @@ describe("GC proposal support", () => {
     0x6e, // ref.null any
     0xd4,
     0x00, // br_on_null 0
+    0xd6,
+    0x00, // br_on_non_null 0
     0xfb,
     0x30,
     0x00, // rtt.canon 0
@@ -1455,6 +1457,7 @@ describe("GC proposal support", () => {
     "    block $label0",
     "      ref.null any",
     "      br_on_null $label0",
+    "      br_on_non_null $label0",
     "      rtt.canon $structA",
     "      br_on_cast $label0",
     "      br_on_cast_fail $label0",


### PR DESCRIPTION
From the "reference types" proposal:
- select_with_type

From the "function references" proposal:
- br_on_non_null

From the latest updates to the GC proposal:
- br_on_cast_fail
- br_on_non_func
- br_on_non_data
- br_on_non_i31

Not yet standardized experiments in V8:
- array.copy
- rtt.fresh_sub