### PR TITLE
Prevent negative name subsection length

### DIFF
--- a/src/WasmParser.ts
+++ b/src/WasmParser.ts
@@ -2371,7 +2371,7 @@ export class BinaryReader {
       this._pos = pos;
       return false;
     }
-    var payloadLength = this.readVarUint32();
+    var payloadLength = this.readVarUint32() >>> 0;
     if (!this.hasBytes(payloadLength)) {
       this._pos = pos;
       return false;

--- a/test/WasmDis.test.ts
+++ b/test/WasmDis.test.ts
@@ -726,6 +726,41 @@ describe("NameSectionReader", () => {
     expect(nr.getGlobalName(2, true)).toBe("$42");
     expect(nr.getGlobalName(2, false)).toBe("$42 (;2;)");
   });
+
+  test("Wasm module with negative name subsection length", () => {
+    const data = new Uint8Array([
+      // Wasm header
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      // name section
+      0x00, // id
+      0x0b, // size
+      // 'name'
+      0x04,
+      0x6e,
+      0x61,
+      0x6d,
+      0x65,
+      // Malformed name subsection length
+      0x0f, // unsupported (invalid) id
+      0xfa,
+      0xff,
+      0xff,
+      0xff,
+      0x0f, // negative length (-6)
+    ]);
+    const reader = new BinaryReader();
+    reader.setData(data.buffer, 0, data.byteLength);
+
+    const nsr = new NameSectionReader();
+    expect(nsr.read(reader)).toBe(false);
+  });
 });
 
 describe("WasmDisassembler with export metadata", () => {


### PR DESCRIPTION
Reads name sub section length as unsigned.

Without this patch (Chrome DevTools):\
![image](https://user-images.githubusercontent.com/68395886/136623625-5508fd6e-a16f-421d-9f42-e64875c44ae1.png)

With this patch there is no error.
